### PR TITLE
Fix extension build by closing function and declaring chrome

### DIFF
--- a/hermes-extension/src/scratchPad.ts
+++ b/hermes-extension/src/scratchPad.ts
@@ -3,6 +3,8 @@ import { getRoot } from './root.ts';
 import { t } from '../i18n.js';
 import { saveDataToBackground } from './storage/index.ts';
 
+declare const chrome: any;
+
 const SCRATCH_KEY = 'hermes_scratch_notes_ext';
 
 interface Note { title: string; content: string; }

--- a/hermes-extension/src/ui.ts
+++ b/hermes-extension/src/ui.ts
@@ -260,6 +260,9 @@ function updateMacroSubmenuContents(menu: HTMLElement) {
   }
 }
 
+  // close updateMacroSubmenuContents
+}
+
 // === Macro Editor Panel ===
 function toggleMacroEditor(show: boolean, macroName?: string) {
   const panelId = 'hermes-macro-editor';


### PR DESCRIPTION
## Summary
- declare global `chrome` in `scratchPad.ts`
- close `updateMacroSubmenuContents` properly
- run tests and build the extension

## Testing
- `npm test` in `hermes-extension`
- `npm test` in `server`
- `npm run build` in `hermes-extension`

------
https://chatgpt.com/codex/tasks/task_e_6851c6b0eedc8332bc908f959ee375e6