### PR TITLE
Fix UI submenu export buttons

### DIFF
--- a/hermes-extension/src/ui.ts
+++ b/hermes-extension/src/ui.ts
@@ -252,19 +252,19 @@ function updateMacroSubmenuContents(menu: HTMLElement) {
   }
   const importBtn = createSubButton(t('IMPORT_MACROS'), () => importMacrosFromFile());
   menu.appendChild(importBtn);
+
   if (names.length) {
-  const exportBtn = createSubButton(t('EXPORT_MACROS'), () => exportMacros());
-  if (allNames.length) {
-  const exportBtn = createSubButton('Export All Macros...', () => exportMacros());
-  menu.appendChild(exportBtn);
+    const exportBtn = createSubButton(t('EXPORT_MACROS'), () => exportMacros());
+    menu.appendChild(exportBtn);
   }
 
+  if (allNames.length) {
+    const exportAllBtn = createSubButton('Export All Macros...', () => exportMacros());
+    menu.appendChild(exportAllBtn);
+  }
 }
 
-}
-
-  // close updateMacroSubmenuContents
-}
+// close updateMacroSubmenuContents
 
 // === Macro Editor Panel ===
 function toggleMacroEditor(show: boolean, macroName?: string) {


### PR DESCRIPTION
## Summary
- fix invalid braces in Hermes UI export buttons
- ensure export buttons attach to the macro submenu

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685df24507ec8332978b60a9e1a2b71b