### PR TITLE
Improve React tests

### DIFF
--- a/hermes-extension/test/options.test.tsx
+++ b/hermes-extension/test/options.test.tsx
@@ -1,12 +1,15 @@
 import * as React from 'react';
 import { createRoot } from 'react-dom/client';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import { OptionsApp } from '../src/options.tsx';
 
 const THEME_KEY = 'hermes_theme_ext';
 const CUSTOM_THEMES_KEY = 'hermes_custom_themes_ext';
 
 describe('OptionsApp', () => {
+  beforeAll(() => {
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  });
   beforeEach(() => {
     (global as any).chrome = {
       storage: {

--- a/server/test/api.test.js
+++ b/server/test/api.test.js
@@ -1,7 +1,16 @@
 const request = require('supertest');
 const app = require('../index');
+const schedule = require('node-schedule');
 
 describe('API endpoints', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
   test('GET /api/macros returns list of macros', async () => {
     const res = await request(app).get('/api/macros');
     expect(res.status).toBe(200);
@@ -47,5 +56,9 @@ describe('API endpoints', () => {
     expect(up.status).toBe(200);
     const res = await request(app).get('/api/macros/data');
     expect(res.body).toEqual(data);
+  });
+
+  afterAll(async () => {
+    await schedule.gracefulShutdown();
   });
 });


### PR DESCRIPTION
## Summary
- remove deprecated usage of `react-dom/test-utils` act
- ensure React test environment configured for act
- clean up Node timers in server tests

## Testing
- `npm test` (server)
- `npm test` (hermes-extension)


------
https://chatgpt.com/codex/tasks/task_e_686bedc7027483329bcc45b3141249c7