### PR TITLE
Add onboarding overlay feature

### DIFF
--- a/hermes-extension/i18n.js
+++ b/hermes-extension/i18n.js
@@ -38,7 +38,9 @@ export const translations = {
     OK: 'OK',
     IMPORT_FAILED: 'Import Failed',
     ALLOWED_DOMAINS: 'Allowed Domains',
-    ADD: 'Add'
+    ADD: 'Add',
+    ONBOARD_TITLE: 'Welcome to Hermes',
+    ONBOARD_MSG: 'Use the toolbar to fill forms and record macros. Open settings with the gear icon.'
   },
   es: {
     HERMES_OPTIONS: 'Opciones de Hermes',
@@ -79,7 +81,9 @@ export const translations = {
     OK: 'Aceptar',
     IMPORT_FAILED: 'Fall\u00f3 la importaci\u00f3n',
     ALLOWED_DOMAINS: 'Dominios permitidos',
-    ADD: 'A\u00f1adir'
+    ADD: 'A\u00f1adir',
+    ONBOARD_TITLE: 'Bienvenido a Hermes',
+    ONBOARD_MSG: 'Usa la barra para grabar macros o rellenar formularios. Abre ajustes con el icono de engranaje.'
   }
 };
 

--- a/hermes-extension/src/background.js
+++ b/hermes-extension/src/background.js
@@ -20,6 +20,7 @@ const STORAGE_KEYS = {
     BUNCHED_STATE: 'hermes_bunched_state_ext',
     EFFECTS_STATE: 'hermes_effects_state_ext',
     HELP_PANEL_OPEN: 'hermes_help_panel_state_ext',
+    ONBOARDED: 'hermes_onboarded_ext',
     SETTINGS: 'hermes_settings_v1_ext',
     DISABLED_HOSTS: 'hermes_disabled_hosts_ext',
     GITHUB_RAW_BASE: 'github_raw_base',
@@ -98,6 +99,7 @@ let hermesState = {
     whitelist: [],
     disabledHosts: [],
     helpPanelOpen: false,
+    onboarded: false,
     configs: {}
 };
 
@@ -233,7 +235,8 @@ async function initializeHermesState() {
         [STORAGE_KEYS.POSITION]: JSON.stringify({ top: null, left: null }),
         [STORAGE_KEYS.WHITELIST]: '[]',
         [STORAGE_KEYS.HELP_PANEL_OPEN]: false,
-        [STORAGE_KEYS.DISABLED_HOSTS]: '[]'
+        [STORAGE_KEYS.DISABLED_HOSTS]: '[]',
+        [STORAGE_KEYS.ONBOARDED]: false
     };
 
     try {
@@ -274,6 +277,7 @@ async function initializeHermesState() {
         hermesState.whitelist = safeParse(STORAGE_KEYS.WHITELIST, []);
         hermesState.disabledHosts = safeParse(STORAGE_KEYS.DISABLED_HOSTS, []);
         hermesState.helpPanelOpen = storedData[STORAGE_KEYS.HELP_PANEL_OPEN];
+        hermesState.onboarded = storedData[STORAGE_KEYS.ONBOARDED];
 
         // Ensure built-in themes are stored for future reference/consistency
         chrome.storage.local.set({
@@ -461,6 +465,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                     case STORAGE_KEYS.DISABLED_HOSTS: hermesState.disabledHosts = value; break;
                     case STORAGE_KEYS.CUSTOM_THEMES: hermesState.customThemes = value; break;
                     case STORAGE_KEYS.HELP_PANEL_OPEN: hermesState.helpPanelOpen = value; break;
+                    case STORAGE_KEYS.ONBOARDED: hermesState.onboarded = value; break;
                     default:
                         console.warn("Hermes BG: Unknown key for SAVE_HERMES_DATA:", key);
                         successfullyUpdatedInMemoryState = false;

--- a/hermes-extension/src/content.js
+++ b/hermes-extension/src/content.js
@@ -3,12 +3,14 @@ import { toggleMinimizedUI } from './ui/setup.ts';
 import { initEffects } from './effects.ts';
 import { initMacros } from './macros.ts';
 import { ensureSiteConfig } from './domScanner.ts';
+import { checkOnboarding } from './onboarding.ts';
 
 export function init() {
   initUI();
   initEffects();
   initMacros();
   ensureSiteConfig();
+  checkOnboarding();
 }
 
 document.addEventListener('DOMContentLoaded', init);

--- a/hermes-extension/src/onboarding.ts
+++ b/hermes-extension/src/onboarding.ts
@@ -1,0 +1,36 @@
+import { getRoot } from './root.ts';
+import { createModal } from './ui/components.js';
+import { saveDataToBackground } from './storage/index.ts';
+import { t } from '../i18n.js';
+
+let panel: HTMLElement | null = null;
+
+function createPanel(): HTMLElement {
+  const content = `<p>${t('ONBOARD_MSG')}</p>`;
+  const root = getRoot();
+  const buttons = `<button id="hermes-onboard-ok">${t('OK')}</button>`;
+  const p = createModal(
+    root instanceof ShadowRoot ? root : document.body,
+    'hermes-onboard-panel',
+    t('ONBOARD_TITLE'),
+    content,
+    '400px',
+    buttons
+  );
+  p.querySelector('#hermes-onboard-ok')?.addEventListener('click', () => {
+    p.style.display = 'none';
+    saveDataToBackground('hermes_onboarded_ext', true).catch(e =>
+      console.error('Hermes CS: failed to save onboarding', e)
+    );
+  });
+  return p;
+}
+
+export function checkOnboarding() {
+  chrome.storage.local.get(['hermes_onboarded_ext'], data => {
+    if (!data.hermes_onboarded_ext) {
+      if (!panel) panel = createPanel();
+      panel.style.display = 'block';
+    }
+  });
+}

--- a/hermes-extension/src/ui/components.js
+++ b/hermes-extension/src/ui/components.js
@@ -28,7 +28,7 @@ export function createModal(root, id, title, contentHtml, maxWidth = '600px', cu
     if (root instanceof ShadowRoot) {
       root.appendChild(panel);
     } else {
-      root.body.appendChild(panel);
+      (root.body || root).appendChild(panel);
     }
     const closeButton = panel.querySelector('.hermes-panel-close');
     if (closeButton) closeButton.addEventListener('click', () => {

--- a/hermes-extension/test/onboarding.test.ts
+++ b/hermes-extension/test/onboarding.test.ts
@@ -1,0 +1,25 @@
+import { checkOnboarding } from '../src/onboarding.ts';
+import { setRoot } from '../src/root.ts';
+
+describe('onboarding', () => {
+  beforeEach(() => {
+    (global as any).chrome = {
+      storage: { local: { get: (_: any, cb: (data: any) => void) => cb({}) } }
+    };
+    document.documentElement.innerHTML = '<body></body>';
+    document.body.innerHTML = '';
+    setRoot(document as any);
+  });
+
+  afterEach(() => {
+    delete (global as any).chrome;
+  });
+
+  test('shows panel when not onboarded', async () => {
+    checkOnboarding();
+    await new Promise(res => setTimeout(res, 0));
+    const panel = document.getElementById('hermes-onboard-panel');
+    expect(panel).not.toBeNull();
+    expect(panel?.style.display).toBe('block');
+  });
+});


### PR DESCRIPTION
## Summary
- implement onboarding overlay and translations
- wire onboarding check in content script
- persist onboarding state in background service worker
- ensure modal works without `body` in test environment
- test onboarding overlay

## Testing
- `npm test` in `server`
- `npm test` in `hermes-extension`


------
https://chatgpt.com/codex/tasks/task_e_686bf06d03c88332b6ad3a8788e2551e