### PR TITLE
Add demo site

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,11 @@ Press **Schedule Macro** to save. Scheduled jobs can be viewed or cancelled via 
 
 In addition to manual playback, Hermes exposes a local automation API under `/api`.  Macros and form fills can be triggered remotely or chained from other tools.  When the extension scans a new site it automatically saves a configuration file back to your GitHub repository so later automation runs consistently.  The web UI at `/schedule` provides a simple calendar view for creating one‑off or recurring jobs using those saved macros.
 
+## 🌐 Demo Site
+
+After starting the server, open [http://localhost:3000/demo.html](http://localhost:3000/demo.html) to try Hermes on a page with example forms and dynamic elements.  Use this page to practice the form filler, record macros and experiment with theming.
+Open http://localhost:3000/advanced-demo.html for a more sophisticated demo with isolated iframes and a secure login example.
+
 ---
 
 ## 🚀 Development Setup & Testing

--- a/server/public/advanced-demo.html
+++ b/server/public/advanced-demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Hermes Advanced Demo</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2em; }
+    section { margin-bottom: 2em; }
+    label { display: block; margin-bottom: 0.5em; }
+    iframe { width: 100%; height: 300px; border: 1px solid #ccc; }
+  </style>
+</head>
+<body>
+  <h1>Hermes Advanced Demo Site</h1>
+  <p>This page demonstrates Hermes in a more complex, component-isolated environment.</p>
+  <section>
+    <h2>Secure Login</h2>
+    <form id="loginForm" autocomplete="off">
+      <label>Username <input type="text" name="username"></label>
+      <label>Password <input type="password" name="password" autocomplete="new-password"></label>
+      <input type="hidden" name="csrf_token" value="abcdef123456">
+      <button type="submit">Log In</button>
+    </form>
+  </section>
+  <section>
+    <h2>Load Profile from Server</h2>
+    <button id="loadProfile">Load Profile</button>
+    <pre id="profileData"></pre>
+  </section>
+  <section>
+    <h2>Embedded Contact Form</h2>
+    <iframe src="demo.html"></iframe>
+  </section>
+  <section>
+    <h2>Embedded Scheduler</h2>
+    <iframe src="schedule.html"></iframe>
+  </section>
+  <script>
+    document.getElementById('loginForm').addEventListener('submit', e => {
+      e.preventDefault();
+      alert('Logged in (demo only)');
+    });
+    document.getElementById('loadProfile').addEventListener('click', async () => {
+      const res = await fetch('/api/profile');
+      const data = await res.json();
+      document.getElementById('profileData').textContent = JSON.stringify(data, null, 2);
+    });
+  </script>
+</body>
+</html>

--- a/server/public/demo.html
+++ b/server/public/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Hermes Demo</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2em; }
+    form { margin-bottom: 2em; }
+    label { display: block; margin-bottom: 0.5em; }
+    .panel { border: 1px solid #ccc; padding: 1em; margin-top: 1em; display: none; }
+  </style>
+</head>
+<body>
+  <h1>Hermes Extension Demo Site</h1>
+  <p>This page includes sample forms and dynamic elements to test the Hermes extension.</p>
+
+  <h2>Contact Form</h2>
+  <form id="contactForm">
+    <label>First Name <input type="text" name="first"></label>
+    <label>Last Name <input type="text" name="last"></label>
+    <label>Email <input type="email" name="email"></label>
+    <label>Address <input type="text" name="address"></label>
+    <label>City <input type="text" name="city"></label>
+    <label>Subscribe <input type="checkbox" name="subscribe"></label>
+    <button type="submit">Submit</button>
+  </form>
+
+  <h2>Signup Wizard</h2>
+  <button id="toggle">Start Wizard</button>
+  <div class="panel" id="wizard">
+    <p>Step 1: Enter your username</p>
+    <input type="text" name="username">
+    <p>Step 2: Choose a password</p>
+    <input type="password" name="password">
+    <p>Step 3: Click finish</p>
+    <button id="finish">Finish</button>
+  </div>
+
+  <script>
+    document.getElementById('toggle').addEventListener('click', () => {
+      const wiz = document.getElementById('wizard');
+      wiz.style.display = wiz.style.display === 'block' ? 'none' : 'block';
+    });
+    document.getElementById('finish').addEventListener('click', () => {
+      alert('Wizard complete!');
+    });
+    document.getElementById('contactForm').addEventListener('submit', e => {
+      e.preventDefault();
+      alert('Form submitted!');
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add advanced demo page with login widget and embedded frames
- document advanced demo page location in README

## Testing
- `./setup.sh`
- `cd server && npm test`
- `cd ../hermes-extension && npm test`


------
https://chatgpt.com/codex/tasks/task_e_686ec69de17483329b50044b94f61822