### PR TITLE
Fix extension build errors

### DIFF
--- a/hermes-extension/src/defaultSettings.ts
+++ b/hermes-extension/src/defaultSettings.ts
@@ -96,7 +96,7 @@ export const defaultSettings = {
   "_comment_useCoordinateFallback": "When elements can't be found by selector, use recorded x/y coordinates or DOM path.",
   "similarityThreshold": 0.5,
   "_comment_similarityThreshold": "Minimum similarity score (0-1) for heuristic field matching. Default: 0.5."
-  }
+  },
   "_comment_recordHotkey": "Key combo to start/stop recording (e.g., Ctrl+Shift+R).",
   "recordHotkey": "Ctrl+Shift+R",
   "_comment_playMacroHotkey": "Key combo to play the last macro (e.g., Ctrl+Shift+P).",

--- a/hermes-extension/src/tasks.ts
+++ b/hermes-extension/src/tasks.ts
@@ -84,7 +84,6 @@ function createPanel(root: HTMLElement | ShadowRoot): HTMLElement {
 
 export function toggleTasks(show: boolean) {
   const root = getRoot();
-  if (!pane
-l && show) panel = createPanel(root instanceof ShadowRoot ? root : document.body);
+  if (!panel && show) panel = createPanel(root instanceof ShadowRoot ? root : document.body);
   if (panel) panel.style.display = show ? 'block' : 'none';
 }


### PR DESCRIPTION
## Summary
- resolve syntax error in `defaultSettings.ts`
- fix typo in `tasks.ts` preventing compilation
- run tests in `hermes-extension` and `server`

## Testing
- `npm test` in `hermes-extension`
- `npm test` in `server`


------
https://chatgpt.com/codex/tasks/task_e_687872dfe3fc8332bd0f9872f2f4e21e