### PR TITLE
Add dock mode to serverless extension

### DIFF
--- a/hermes-serverless-extension/README.md
+++ b/hermes-serverless-extension/README.md
@@ -8,6 +8,6 @@ This directory contains a lightweight version of the Hermes extension that runs 
 2. Enable developer mode and load this folder as an unpacked extension.
 3. Browse any page to see the Hermes overlay and tools. Data is stored in `localStorage`.
 
-This version now supports keyboard hotkeys, profile import/export, a Cube 3D visual effect using Three.js loaded from a CDN, a scratch pad for notes, task list management, macro scheduling, and a simple Pomodoro timer.
+This version now supports keyboard hotkeys, profile import/export, a Cube 3D visual effect using Three.js loaded from a CDN, a scratch pad for notes, task list management, macro scheduling, a simple Pomodoro timer, a domain allowlist, and a dockable toolbar for quick top or bottom placement.
 
 This variant is intended for demonstrations and offline use only.


### PR DESCRIPTION
## Summary
- add docking state storage and applyDockMode logic
- include dock buttons in snap controls
- update serverless README with allowlist and docking info
- add initialization call to applyDockMode

## Testing
- `npm test` in `hermes-extension`
- `npm test` in `server`


------
https://chatgpt.com/codex/tasks/task_e_68787305fa548332837857d6127f97dd