### PR TITLE
Secure token handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,25 +152,19 @@ it later.
 ### GitHub Settings
 
 The extension expects the URLs for the remote config repository to be provided
-via Chrome storage or build-time environment variables.
+via Chrome storage or build-time environment variables. Tokens should be
+retrieved from environment variables or your OS credential store instead of
+persisting them in Chrome storage.
 
 - **`github_raw_base`** – Base URL for raw config files
 - **`github_api_base`** – API endpoint for creating/updating configs
-- **`github_token`** – Personal token for write access (optional)
 
-You can set these at runtime with:
+Tokens should **not** be stored using `chrome.storage`. Instead, supply a GitHub
+personal access token through the `GITHUB_TOKEN` environment variable or your OS
+keychain.
 
-```javascript
-chrome.storage.local.set({
-  github_raw_base: 'https://raw.githubusercontent.com/USER/REPO/main/_Configs/',
-  github_api_base: 'https://api.github.com/repos/USER/REPO/contents/_Configs/',
-  github_token: 'ghp_xxx' // optional
-});
-```
-
-Alternatively, define the environment variables `GITHUB_RAW_BASE`,
-`GITHUB_API_BASE`, and `GITHUB_TOKEN` when running `npm run build` to embed them
-in the bundle.
+Define the environment variables `GITHUB_RAW_BASE`, `GITHUB_API_BASE`, and
+`GITHUB_TOKEN` when running `npm run build` to embed them in the bundle.
 
 ---
 

--- a/hermes-extension/src/background.js
+++ b/hermes-extension/src/background.js
@@ -28,7 +28,6 @@ const STORAGE_KEYS = {
     DISABLED_HOSTS: 'hermes_disabled_hosts_ext',
     GITHUB_RAW_BASE: 'github_raw_base',
     GITHUB_API_BASE: 'github_api_base',
-    GITHUB_TOKEN: 'github_token',
     BUILT_IN_THEMES: 'hermes_built_in_themes' // For internal storage of built-in themes if needed
 };
 
@@ -74,12 +73,11 @@ let githubConfig = {
 async function loadGithubSettings() {
     const data = await chrome.storage.local.get({
         [STORAGE_KEYS.GITHUB_RAW_BASE]: '',
-        [STORAGE_KEYS.GITHUB_API_BASE]: '',
-        [STORAGE_KEYS.GITHUB_TOKEN]: ''
+        [STORAGE_KEYS.GITHUB_API_BASE]: ''
     });
     githubConfig.rawBase = data[STORAGE_KEYS.GITHUB_RAW_BASE] || process.env.GITHUB_RAW_BASE || '';
     githubConfig.apiBase = data[STORAGE_KEYS.GITHUB_API_BASE] || process.env.GITHUB_API_BASE || '';
-    githubConfig.token = data[STORAGE_KEYS.GITHUB_TOKEN] || process.env.GITHUB_TOKEN || '';
+    githubConfig.token = process.env.GITHUB_TOKEN || '';
 }
 
 // --- In-memory cache for Hermes data ---


### PR DESCRIPTION
## Summary
- avoid persisting GitHub token in chrome storage
- load token from environment variables only
- allow providing Google Drive token via env var
- update README with secure token guidance

## Testing
- `npm test --silent --prefix server`
- `npm test --silent --prefix hermes-extension`


------
https://chatgpt.com/codex/tasks/task_e_68791e519c9883328c136daf92816449