### PR TITLE
Fix macro play call in React panel

### DIFF
--- a/hermes-extension/hermes-react-refactor/src/components/MacroPanel.tsx
+++ b/hermes-extension/hermes-react-refactor/src/components/MacroPanel.tsx
@@ -11,7 +11,9 @@ const MacroPanel: React.FC = () => {
   const { macros } = useSelector((state: RootState) => state.macros);
 
   const handlePlay = (name: string) => {
-    macroEngine.play(name, macros);
+    // Play the macro by name. The macro engine manages its own store so we
+    // simply call play with the macro name. 🎬
+    macroEngine.play(name);
   };
 
   const handleDelete = (name: string) => {


### PR DESCRIPTION
## Summary
- use updated `macroEngine.play` signature in `MacroPanel`

## Testing
- `npm run build` within `hermes-react-refactor` *(fails: Option 'allowImportingTsExtensions' can only be used when either 'noEmit' or 'emitDeclarationOnly' is set)*
- `npm test` within `hermes-extension` *(fails to run: Cannot find module `@hermes/core`)*
- `npm test` within `server`

------
https://chatgpt.com/codex/tasks/task_e_687934be7b9883329ba7bbf2fc68d645