### PR TITLE
Fix macro panel play call and ESM imports

### DIFF
--- a/hermes-extension/hermes-react-refactor/src/App.tsx
+++ b/hermes-extension/hermes-react-refactor/src/App.tsx
@@ -56,7 +56,8 @@ const App: React.FC = () => {
   };
 
   const handleFill = async () => {
-    const skipped = await fillForm(profile);
+    // Provide default settings when filling so the call matches the new API
+    const skipped = await fillForm(profile, {});
     if (skipped.length > 0) {
       alert(`${skipped.length} field(s) were not filled. Use the 'Train' button to improve accuracy.`);
     } else {

--- a/hermes-extension/hermes-react-refactor/src/components/MacroPanel.tsx
+++ b/hermes-extension/hermes-react-refactor/src/components/MacroPanel.tsx
@@ -11,7 +11,9 @@ const MacroPanel: React.FC = () => {
   const { macros } = useSelector((state: RootState) => state.macros);
 
   const handlePlay = (name: string) => {
-    macroEngine.play(name, macros);
+    // Play the macro by name. The macro engine manages its own store so we
+    // simply call play with the macro name. 🎬
+    macroEngine.play(name);
   };
 
   const handleDelete = (name: string) => {

--- a/hermes-extension/hermes-react-refactor/src/index.tsx
+++ b/hermes-extension/hermes-react-refactor/src/index.tsx
@@ -1,15 +1,5 @@
 // hermes-react-refactor/src/index.tsx
 
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import './index.css'; // Standard create-react-app css
-import Content from './content'; // We will create a Content component
-
-const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement
-);
-root.render(
-  <React.StrictMode>
-    <Content />
-  </React.StrictMode>
-);
+import './index.css';
+// Importing the content script triggers the UI injection 👍
+import './content';

--- a/hermes-extension/hermes-react-refactor/src/services/trainerService.ts
+++ b/hermes-extension/hermes-react-refactor/src/services/trainerService.ts
@@ -4,7 +4,8 @@ import { fillForm, ProfileData, SkippedField } from '@hermes/core';
 import { saveDataToBackground } from './storageService';
 
 export async function startHeuristicTraining(profile: ProfileData): Promise<SkippedField[]> {
-  const skipped = await fillForm(profile);
+  // Pass default settings so fillForm doesn't expect them from callers
+  const skipped = await fillForm(profile, {});
   return skipped;
 }
 

--- a/hermes-extension/hermes-react-refactor/tsconfig.json
+++ b/hermes-extension/hermes-react-refactor/tsconfig.json
@@ -6,6 +6,7 @@
     "checkJs": false,
     "outDir": "dist",
     "allowImportingTsExtensions": true,
+    "noEmit": true,
     "jsx": "react-jsx",
     "moduleResolution": "node",
     "esModuleInterop": true,

--- a/packages/core/src/effectsEngine.ts
+++ b/packages/core/src/effectsEngine.ts
@@ -1,4 +1,5 @@
-import { getRoot } from './root';
+// Use explicit extension for ESM compatibility 😄
+import { getRoot } from './root.js';
 import * as THREE from 'three';
 
 let canvas: HTMLCanvasElement | null = null;

--- a/packages/core/src/formFiller.ts
+++ b/packages/core/src/formFiller.ts
@@ -1,4 +1,5 @@
-import { ProfileData, SkippedField, matchProfileKey, getAssociatedLabelText } from './heuristics';
+// Explicit extension ensures Node ESM can resolve this import.
+import { ProfileData, SkippedField, matchProfileKey, getAssociatedLabelText } from './heuristics.js';
 
 export interface FormFillSettings {
   collectSkipped?: boolean;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,8 @@
-export * from './formFiller';
-export * from './macroEngine';
-export * from './effectsEngine';
-export * from './heuristics';
-export * from './root';
-export * from './storage';
-export * from './debug';
+// Explicit file extensions are required for ESM consumers like Jest. 😄
+export * from './formFiller.js';
+export * from './macroEngine.js';
+export * from './effectsEngine.js';
+export * from './heuristics.js';
+export * from './root.js';
+export * from './storage/index.js';
+export * from './debug.js';

--- a/packages/core/src/macroEngine.ts
+++ b/packages/core/src/macroEngine.ts
@@ -1,7 +1,7 @@
-import { saveDataToBackground, getInitialData } from './storage/index';
-import { addDebugLog } from './debug';
+import { saveDataToBackground, getInitialData } from './storage/index.js';
+import { addDebugLog } from './debug.js';
 
-interface MacroEvent {
+export interface MacroEvent {
   type: string;
   selector: string | null;
   value?: string | null;


### PR DESCRIPTION
## Summary
- call `macroEngine.play(name)` directly in `MacroPanel`
- compile React refactor project without emitting JS
- default the heuristic trainer and fillForm calls to use new API
- load content script by importing it for side effects
- export `MacroEvent` and fix ESM import paths in `@hermes/core`

## Testing
- `npm run build` in `hermes-extension/hermes-react-refactor`
- `npm test` in `hermes-extension`
- `npm test` in `server`


------
https://chatgpt.com/codex/tasks/task_e_687934be7b9883329ba7bbf2fc68d645