### PR TITLE
Fix extension storage alias and tests

### DIFF
--- a/hermes-extension/jest.config.cjs
+++ b/hermes-extension/jest.config.cjs
@@ -1,3 +1,6 @@
+const { pathsToModuleNameMapper } = require('ts-jest');
+const { compilerOptions } = require('./tsconfig.json');
+
 module.exports = {
   preset: 'ts-jest/presets/js-with-ts-esm',
   testEnvironment: 'jsdom',
@@ -5,5 +8,8 @@ module.exports = {
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
   transform: {
     '^.+\\.(ts|tsx|js)$': ['ts-jest', { useESM: true }]
-  }
+  },
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
+    prefix: '<rootDir>/'
+  })
 };

--- a/hermes-extension/src/storage/index.ts
+++ b/hermes-extension/src/storage/index.ts
@@ -1,1 +1,1 @@
-export { saveDataToBackground, getInitialData } from '@hermes/core/dist/storage/index.js';
+export { saveDataToBackground, getInitialData } from '@hermes/core/storage';


### PR DESCRIPTION
## Summary
- use workspace alias for storage functions instead of dist path
- allow Jest to resolve `@hermes/core` via `pathsToModuleNameMapper`

## Testing
- `npx tsc --noEmit`
- `npm test` in `hermes-extension`
- `npm test` in `server`


------
https://chatgpt.com/codex/tasks/task_e_6879348f3fb48332b42b9e1689c0101b