### PR TITLE
Add simple V14 effects

### DIFF
--- a/hermes-extension/src/localCore.ts
+++ b/hermes-extension/src/localCore.ts
@@ -290,11 +290,13 @@ let canvas: HTMLCanvasElement | null = null;
 let ctx: CanvasRenderingContext2D | null = null;
 let flakes: { x: number; y: number; r: number; s: number }[] = [];
 let lasers: { x: number; y: number; len: number; s: number }[] = [];
+let lasersV14: { x: number; y: number; len: number; s: number }[] = [];
 let confettiPieces: { x: number; y: number; vx: number; vy: number; color: string; size: number }[] = [];
 let bubbles: { x: number; y: number; r: number; vx: number; vy: number }[] = [];
 let strobeState = { phase: 0, opacity: 0 };
+let strobeStateV14 = { phase: 0, opacity: 0 };
 let running = false;
-let mode: 'none' | 'snow' | 'lasers' | 'cube' | 'confetti' | 'bubbles' | 'strobe' = 'none';
+let mode: 'none' | 'snow' | 'lasers' | 'cube' | 'confetti' | 'bubbles' | 'strobe' | 'laserV14' | 'strobeV14' = 'none';
 
 function initCanvas() {
   if (!canvas) {
@@ -385,24 +387,43 @@ export function startStrobe() {
   mode = 'strobe';
 }
 
+export function startLasersV14() {
+  initCanvas();
+  lasersV14 = [];
+  if (!running) { running = true; loop(); }
+  mode = 'laserV14';
+}
+
+export function startStrobeV14() {
+  initCanvas();
+  strobeStateV14 = { phase: 0, opacity: 0 };
+  if (!running) { running = true; loop(); }
+  mode = 'strobeV14';
+}
+
 export function stopEffects() {
   running = false;
   lasers = [];
+  lasersV14 = [];
   flakes = [];
   confettiPieces = [];
   bubbles = [];
+  strobeState = { phase: 0, opacity: 0 };
+  strobeStateV14 = { phase: 0, opacity: 0 };
   if (canvas) canvas.style.display = 'none';
   mode = 'none';
 }
 
-export function setEffect(newMode: 'none' | 'snow' | 'lasers' | 'cube' | 'confetti' | 'bubbles' | 'strobe') {
+export function setEffect(newMode: 'none' | 'snow' | 'lasers' | 'cube' | 'confetti' | 'bubbles' | 'strobe' | 'laserV14' | 'strobeV14') {
   if (newMode === 'none') { stopEffects(); return; }
   if (newMode === 'snow') { startSnowflakes(); return; }
   if (newMode === 'lasers') { startLasers(); return; }
+  if (newMode === 'laserV14') { startLasersV14(); return; }
   if (newMode === 'cube') { startLasers(); return; } // Simplified cube effect
   if (newMode === 'confetti') { startConfetti(); return; }
   if (newMode === 'bubbles') { startBubbles(); return; }
   if (newMode === 'strobe') { startStrobe(); return; }
+  if (newMode === 'strobeV14') { startStrobeV14(); return; }
 }
 
 export function getEffect() {
@@ -675,6 +696,7 @@ export function setTranslationFunction(translator: (key: string) => string) {
 // Cube effect (simplified)
 export function startCube() {
   startLasers(); // Use lasers as cube effect for now
+  mode = 'cube';
 }
 
 // Analysis sniffer
@@ -866,6 +888,28 @@ function loop() {
       lasers = lasers.filter(l => l.y < canvas!.height);
       break;
 
+    case 'laserV14':
+      if (Math.random() < 0.05 && lasersV14.length < 200) {
+        lasersV14.push({
+          x: Math.random() * canvas.width,
+          y: 0,
+          len: 20 + Math.random() * 50,
+          s: 5 + Math.random() * 10
+        });
+      }
+      lasersV14.forEach(l => {
+        if (!ctx) return;
+        ctx.beginPath();
+        ctx.strokeStyle = 'rgba(255,0,0,0.7)';
+        ctx.lineWidth = 2;
+        ctx.moveTo(l.x, l.y);
+        ctx.lineTo(l.x, l.y - l.len);
+        ctx.stroke();
+        l.y += l.s;
+      });
+      lasersV14 = lasersV14.filter(l => l.y < canvas!.height + l.len);
+      break;
+
     case 'confetti':
       confettiPieces.forEach(p => {
         p.x += p.vx;
@@ -897,6 +941,14 @@ function loop() {
       strobeState.opacity = Math.sin(strobeState.phase) * 0.5 + 0.5;
       if (!ctx) return;
       ctx.fillStyle = `rgba(255,255,255,${strobeState.opacity})`;
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      break;
+
+    case 'strobeV14':
+      strobeStateV14.phase += 0.1;
+      if (!ctx) return;
+      const alpha = (Math.sin(strobeStateV14.phase) * 0.5 + 0.5) * 0.2;
+      ctx.fillStyle = `rgba(255,255,255,${alpha})`;
       ctx.fillRect(0, 0, canvas.width, canvas.height);
       break;
   }

--- a/hermes-extension/src/ui.ts
+++ b/hermes-extension/src/ui.ts
@@ -1,6 +1,6 @@
 // === Hermes UI Core - Merged ShadowDOM Edition ===
 
-import { macroEngine, fillForm, getInitialData, saveDataToBackground, startSnowflakes, startLasers, startCube, stopEffects, setEffect } from './localCore.ts';
+import { macroEngine, fillForm, getInitialData, saveDataToBackground, startSnowflakes, startLasers, startCube, stopEffects, setEffect, startLasersV14, startStrobeV14 } from './localCore.ts';
 import { getSettings } from './settings.ts';
 import { applyTheme } from './theme.ts';
 import { themeOptions } from './themeOptions.ts';
@@ -406,6 +406,8 @@ function updateEffectsSubmenu(menu: HTMLElement) {
     { mode: 'none', name: 'None' },
     { mode: 'snow', name: 'Snowflakes' },
     { mode: 'laser', name: 'Lasers' },
+    { mode: 'laserV14', name: 'Lasers V14' },
+    { mode: 'strobeV14', name: 'Strobe V14' },
     { mode: 'cube', name: 'Cube 3D' }
   ];
   opts.forEach(opt => {
@@ -419,6 +421,8 @@ function updateEffectsSubmenu(menu: HTMLElement) {
       currentEffect = opt.mode;
       if (opt.mode === 'snow') startSnowflakes();
       else if (opt.mode === 'laser') startLasers();
+      else if (opt.mode === 'laserV14') startLasersV14();
+      else if (opt.mode === 'strobeV14') startStrobeV14();
       else if (opt.mode === 'cube') startCube();
       else stopEffects();
       saveDataToBackground('hermes_effects_state_ext', opt.mode);


### PR DESCRIPTION
## Summary
- implement a basic V14 laser and strobe in `localCore`
- surface new effects in the UI

## Testing
- `npm test` in `hermes-extension` *(fails: HTMLCanvasElement.getContext not implemented)*
- `npm test` in `server`

------
https://chatgpt.com/codex/tasks/task_e_687c4f75bf448332977b01a39045cf03