### PR TITLE
Add simple V14 effects

### DIFF
--- a/hermes-extension/src/defaultSettings.ts
+++ b/hermes-extension/src/defaultSettings.ts
@@ -81,8 +81,10 @@ export const defaultSettings = {
     "maxOpacity": 0.2,
     "_comment_maxOpacity": "Maximum opacity during strobe. Default: 0.2. Range: 0.0-1.0.",
     "color": "rgba(255, 255, 255, {alpha})",
-    "_comment_color": "Color for the simple strobe. Default: 'rgba(255, 255, 255, {alpha})'."
-  }
+  "_comment_color": "Color for the simple strobe. Default: 'rgba(255, 255, 255, {alpha})'."
+  },
+  "_comment_syncInterval": "Minutes between automatic sync with server. 0 disables.",
+  "syncInterval": 0
   },
   "_comment_macro": "Settings for macro recording/playback and heuristics.",
   "macro": {
@@ -95,10 +97,14 @@ export const defaultSettings = {
   "useCoordinateFallback": false,
   "_comment_useCoordinateFallback": "When elements can't be found by selector, use recorded x/y coordinates or DOM path.",
   "similarityThreshold": 0.5,
-  "_comment_similarityThreshold": "Minimum similarity score (0-1) for heuristic field matching. Default: 0.5."
+  "_comment_similarityThreshold": "Minimum similarity score (0-1) for heuristic field matching. Default: 0.5.",
+  "selectorWaitTimeout": 5000,
+  "_comment_selectorWaitTimeout": "Default timeout in ms for waitForSelector events. Default: 5000.",
+  "networkIdleTimeout": 2000,
+  "_comment_networkIdleTimeout": "Default timeout in ms for waitForNetworkIdle events. Default: 2000."
   },
   "_comment_recordHotkey": "Key combo to start/stop recording (e.g., Ctrl+Shift+R).",
   "recordHotkey": "Ctrl+Shift+R",
-  "_comment_playMacroHotkey": "Key combo to play the last macro (e.g., Ctrl+Shift+P).",
+  "_comment_playMacroHotkey": "Key combo to play the selected macro (e.g., Ctrl+Shift+P).",
   "playMacroHotkey": "Ctrl+Shift+P"
 } as const;

--- a/hermes-extension/src/ui.ts
+++ b/hermes-extension/src/ui.ts
@@ -1,6 +1,6 @@
 // === Hermes UI Core - Merged ShadowDOM Edition ===
 
-import { macroEngine, fillForm, getInitialData, saveDataToBackground, startSnowflakes, startLasers, startCube, stopEffects, setEffect } from './localCore.ts';
+import { macroEngine, fillForm, getInitialData, saveDataToBackground, startSnowflakes, startLasers, startCube, stopEffects, setEffect, startLasersV14, startStrobeV14 } from './localCore.ts';
 import { getSettings } from './settings.ts';
 import { applyTheme } from './theme.ts';
 import { themeOptions } from './themeOptions.ts';
@@ -406,6 +406,8 @@ function updateEffectsSubmenu(menu: HTMLElement) {
     { mode: 'none', name: 'None' },
     { mode: 'snow', name: 'Snowflakes' },
     { mode: 'laser', name: 'Lasers' },
+    { mode: 'laserV14', name: 'Lasers V14' },
+    { mode: 'strobeV14', name: 'Strobe V14' },
     { mode: 'cube', name: 'Cube 3D' }
   ];
   opts.forEach(opt => {
@@ -419,6 +421,8 @@ function updateEffectsSubmenu(menu: HTMLElement) {
       currentEffect = opt.mode;
       if (opt.mode === 'snow') startSnowflakes();
       else if (opt.mode === 'laser') startLasers();
+      else if (opt.mode === 'laserV14') startLasersV14();
+      else if (opt.mode === 'strobeV14') startStrobeV14();
       else if (opt.mode === 'cube') startCube();
       else stopEffects();
       saveDataToBackground('hermes_effects_state_ext', opt.mode);

--- a/hermes-extension/test/effectsEngine.test.ts
+++ b/hermes-extension/test/effectsEngine.test.ts
@@ -26,6 +26,14 @@ describe('startCube', () => {
     document.body.innerHTML = '';
     setRoot(document);
     (global as any).requestAnimationFrame = jest.fn();
+    HTMLCanvasElement.prototype.getContext = jest.fn(() => ({
+      beginPath: jest.fn(),
+      stroke: jest.fn(),
+      moveTo: jest.fn(),
+      lineTo: jest.fn(),
+      fillRect: jest.fn(),
+      clearRect: jest.fn()
+    } as any));
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
- implement a basic V14 laser and strobe in `localCore`
- surface new effects in the UI
- copy default settings from userscript and handle relative macro coordinates
- mock canvas in cube effect tests
- sync extension defaults with userscript

## Testing
- `npm test` in `hermes-extension`
- `npm test` in `server`


------
https://chatgpt.com/codex/tasks/task_e_687c4f75bf448332977b01a39045cf03