### PR TITLE
Enhance demo site with accessibility pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,8 @@ In addition to manual playback, Hermes exposes a local automation API under `/ap
 ## 🌐 Demo Site
 
 Open `demo-site/index.html` directly in your browser to explore Hermes without running a server.  The page contains contact and login forms, a multi-step wizard and dynamic fields so you can try the form filler, heuristics and macro recorder.
-An embedded widget demonstrates filling elements inside iframes.  Simply load the file and activate the extension to begin experimenting.
+`demo-site/corporate.html` offers a larger enterprise form with a high contrast toggle to showcase accessibility features.
+An embedded widget demonstrates filling elements inside iframes. Simply load the file and activate the extension to begin experimenting.
 
 
 ---

--- a/demo-site/corporate.html
+++ b/demo-site/corporate.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Hermes Corporate Demo</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 1em auto; max-width: 900px; }
+    section { margin-bottom: 2em; }
+    label { display: block; margin-bottom: 0.5em; }
+    form { padding: 1em; border: 1px solid #ddd; }
+    table { border-collapse: collapse; width: 100%; margin-top: 1em; }
+    th, td { border: 1px solid #ccc; padding: 0.5em; }
+    body.high-contrast { background: #000; color: #fff; }
+    body.high-contrast input,
+    body.high-contrast textarea { background: #000; color: #fff; border: 1px solid #fff; }
+  </style>
+</head>
+<body>
+  <a href="#main" class="skip-link">Skip to main content</a>
+  <button id="contrastToggle" aria-pressed="false">Toggle High Contrast</button>
+  <h1 id="main">Corporate Data Entry</h1>
+  <p>This form mimics a typical enterprise workflow. Use Hermes to record macros and fill repetitive fields.</p>
+  <form id="corpForm" aria-labelledby="main">
+    <section>
+      <h2>Employee Info</h2>
+      <label>First Name <input name="first" type="text" required></label>
+      <label>Last Name <input name="last" type="text" required></label>
+      <label>Employee ID <input name="empId" type="text" required></label>
+      <label>Email <input name="email" type="email" required></label>
+      <label>Department <input name="dept" type="text"></label>
+    </section>
+    <section>
+      <h2>Address</h2>
+      <label>Street <input name="street" type="text"></label>
+      <label>City <input name="city" type="text"></label>
+      <label>State <input name="state" type="text"></label>
+      <label>Zip <input name="zip" type="text"></label>
+    </section>
+    <section>
+      <h2>Expense Items</h2>
+      <table aria-label="Expense line items">
+        <thead>
+          <tr><th>Description</th><th>Amount</th></tr>
+        </thead>
+        <tbody id="expenseBody">
+          <tr>
+            <td><input name="desc1" type="text" aria-label="Description 1"></td>
+            <td><input name="amt1" type="number" step="0.01" aria-label="Amount 1"></td>
+          </tr>
+        </tbody>
+      </table>
+      <button id="addRow" type="button">Add Row</button>
+    </section>
+    <button type="submit">Submit</button>
+  </form>
+  <script>
+    document.getElementById('contrastToggle').addEventListener('click', () => {
+      const pressed = document.body.classList.toggle('high-contrast');
+      document.getElementById('contrastToggle').setAttribute('aria-pressed', pressed);
+    });
+    document.getElementById('corpForm').addEventListener('submit', e => {
+      e.preventDefault();
+      alert('Corporate form submitted!');
+    });
+    document.getElementById('addRow').addEventListener('click', () => {
+      const tbody = document.getElementById('expenseBody');
+      const count = tbody.children.length + 1;
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td><input name="desc${count}" type="text" aria-label="Description ${count}"></td>` +
+                     `<td><input name="amt${count}" type="number" step="0.01" aria-label="Amount ${count}"></td>`;
+      tbody.appendChild(tr);
+    });
+  </script>
+</body>
+</html>

--- a/demo-site/index.html
+++ b/demo-site/index.html
@@ -11,14 +11,23 @@
     .step { display: none; }
     .step.active { display: block; }
     iframe { width: 100%; border: 1px solid #ccc; height: 300px; }
+    body.high-contrast { background: #000; color: #fff; }
+    body.high-contrast input,
+    body.high-contrast textarea {
+      background: #000;
+      color: #fff;
+      border: 1px solid #fff;
+    }
   </style>
 </head>
 <body>
-  <h1>Hermes Extension Interactive Demo</h1>
+  <a href="#main" class="skip-link">Skip to main content</a>
+  <button id="contrastToggle" aria-pressed="false">Toggle High Contrast</button>
+  <h1 id="main">Hermes Extension Interactive Demo</h1>
   <p>Use this page to practice form filling, record macros and test dynamic elements.</p>
   <section id="contact">
-    <h2>Contact Form</h2>
-    <form id="contactForm">
+    <h2 id="contactHeading">Contact Form</h2>
+    <form id="contactForm" aria-labelledby="contactHeading">
       <label>First Name <input name="first" type="text"></label>
       <label>Last Name <input name="last" type="text"></label>
       <label>Email <input name="email" type="email"></label>
@@ -28,8 +37,8 @@
     </form>
   </section>
   <section id="login">
-    <h2>Login Form</h2>
-    <form id="loginForm">
+    <h2 id="loginHeading">Login Form</h2>
+    <form id="loginForm" aria-labelledby="loginHeading">
       <label>Username <input name="username" type="text" autocomplete="off"></label>
       <label>Password <input name="password" type="password" autocomplete="new-password"></label>
       <button type="submit">Log In</button>
@@ -65,6 +74,10 @@
     <iframe src="widget.html"></iframe>
   </section>
   <script>
+    document.getElementById('contrastToggle').addEventListener('click', () => {
+      const pressed = document.body.classList.toggle('high-contrast');
+      document.getElementById('contrastToggle').setAttribute('aria-pressed', pressed);
+    });
     document.getElementById('contactForm').addEventListener('submit', e => {
       e.preventDefault();
       alert('Contact form submitted!');

--- a/demo-site/widget.html
+++ b/demo-site/widget.html
@@ -6,16 +6,28 @@
   <style>
     body { font-family: Arial, sans-serif; margin: 1em; }
     label { display: block; margin-bottom: 0.5em; }
+    body.high-contrast { background: #000; color: #fff; }
+    body.high-contrast input,
+    body.high-contrast textarea {
+      background: #000;
+      color: #fff;
+      border: 1px solid #fff;
+    }
   </style>
 </head>
 <body>
-  <h3>Support Request</h3>
-  <form id="widgetForm">
-    <label>Issue <input name="issue" type="text"></label>
+  <button id="contrastToggle" aria-pressed="false">Toggle High Contrast</button>
+  <h3 id="widgetHeading">Support Request</h3>
+  <form id="widgetForm" aria-labelledby="widgetHeading">
+    <label>Issue <input name="issue" type="text" aria-required="true"></label>
     <label>Details <textarea name="details"></textarea></label>
     <button type="submit">Send</button>
   </form>
   <script>
+    document.getElementById('contrastToggle').addEventListener('click', () => {
+      const pressed = document.body.classList.toggle('high-contrast');
+      document.getElementById('contrastToggle').setAttribute('aria-pressed', pressed);
+    });
     document.getElementById('widgetForm').addEventListener('submit', e => {
       e.preventDefault();
       alert('Widget form submitted!');


### PR DESCRIPTION
## Summary
- add high-contrast mode and skip links to demo index
- create corporate.html with large accessible form
- update embedded widget for accessibility
- reference new page in README

## Testing
- `npm test` in `hermes-extension`
- `npm test` in `server`


------
https://chatgpt.com/codex/tasks/task_e_688a4c650f788332b765609ae9f203c2