### PR TITLE
feat: apply userscript themes and persist panel state

### DIFF
--- a/hermes-extension/options.html
+++ b/hermes-extension/options.html
@@ -4,8 +4,13 @@
     <meta charset="utf-8">
     <title>Hermes Options</title>
     <style>
-        body { font-family: Arial, sans-serif; padding: 20px; }
-        label { display:block; margin-top: 10px; }
+        body {
+            font-family: Arial, sans-serif;
+            padding: 20px;
+            background: var(--hermes-bg);
+            color: var(--hermes-text);
+        }
+        label { display: block; margin-top: 10px; }
         button { margin-top: 10px; }
     </style>
 </head>

--- a/hermes-extension/src/options.tsx
+++ b/hermes-extension/src/options.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { t } from '../i18n.js';
 import { AffirmationToggle } from './productivity.tsx';
+import { applyTheme } from './theme.ts';
 declare const chrome: any;
 
 const THEME_KEY = 'hermes_theme_ext';
@@ -27,6 +28,10 @@ function OptionsApp() {
       setCurrent(data[THEME_KEY] || 'dark');
     });
   }, []);
+
+  useEffect(() => {
+    applyTheme(current);
+  }, [current]);
 
   const saveTheme = (val: string) => {
     setCurrent(val);
@@ -62,11 +67,28 @@ function OptionsApp() {
   const allThemes = { ...builtIn, ...custom };
 
   return (
-    <div>
+    <div
+      style={{
+        background: 'var(--hermes-panel-bg)',
+        color: 'var(--hermes-panel-text)',
+        padding: '10px',
+        border: '1px solid var(--hermes-panel-border)',
+        lineHeight: 'var(--hermes-line-height)'
+      }}
+    >
       <h1>{t('HERMES_OPTIONS')}</h1>
       <label>
         {t('THEME_LABEL')}
-        <select value={current} onChange={e => saveTheme(e.target.value)} id="themeSelect">
+        <select
+          value={current}
+          onChange={e => saveTheme(e.target.value)}
+          id="themeSelect"
+          style={{
+            background: 'var(--hermes-input-bg)',
+            color: 'var(--hermes-input-text)',
+            border: '1px solid var(--hermes-input-border)'
+          }}
+        >
           {Object.keys(allThemes).map(key => (
             <option key={key} value={key}>
               {allThemes[key].emoji} {allThemes[key].name}
@@ -75,9 +97,23 @@ function OptionsApp() {
         </select>
       </label>
       <div>
-        <button onClick={exportThemes} id="exportThemes">{t('EXPORT_THEMES')}</button>
-        <input id="importFile" type="file" accept="application/json" style={{ display: 'none' }} onChange={e => importThemes(e.target.files)} />
-        <button onClick={() => document.getElementById('importFile')!.click()} id="importThemes">{t('IMPORT_THEMES')}</button>
+        <button onClick={exportThemes} id="exportThemes" className="hermes-button">
+          {t('EXPORT_THEMES')}
+        </button>
+        <input
+          id="importFile"
+          type="file"
+          accept="application/json"
+          style={{ display: 'none' }}
+          onChange={e => importThemes(e.target.files)}
+        />
+        <button
+          onClick={() => document.getElementById('importFile')!.click()}
+          id="importThemes"
+          className="hermes-button"
+        >
+          {t('IMPORT_THEMES')}
+        </button>
       </div>
       <AffirmationToggle />
     </div>

--- a/hermes-extension/src/ui.ts
+++ b/hermes-extension/src/ui.ts
@@ -3,7 +3,6 @@
 import { macroEngine, fillForm, getInitialData, saveDataToBackground, startSnowflakes, startLasers, startCube, stopEffects, setEffect, startLasersV14, startStrobeV14, startConfetti, startBubbles, startStrobe, getRoot } from './localCore.ts';
 import { getSettings } from './settings.ts';
 import { applyTheme } from './theme.ts';
-import { themeOptions } from './themeOptions.ts';
 import { loadSettings, toggleSettingsPanel } from './settings.ts';
 import { setupUI, toggleMinimizedUI } from './ui/setup.ts';
 import { createModal } from './ui/components.js';
@@ -94,7 +93,7 @@ export async function initUI() {
   shadowRoot = shadowHost.attachShadow({ mode: 'open' });
 
   // ----- UI ROOT -----
-  const container = setupUI(undefined, data.dockMode || 'none');
+  const container = setupUI(undefined, data.dockMode || 'none', data.isBunched, data.uiPosition);
   shadowRoot.appendChild(container);
 
   // ----- Panel Menus -----
@@ -429,9 +428,11 @@ function toggleMacroEditor(show: boolean, macroName?: string) {
 }
 
 // === Theme and Effects Panels ===
-function updateThemeSubmenu(menu: HTMLElement) {
+async function updateThemeSubmenu(menu: HTMLElement) {
   menu.innerHTML = '';
-  Object.entries(themeOptions).forEach(([key, opt]) => {
+  const data = await getInitialData();
+  const allThemes = { ...(data.builtInThemes || {}), ...(data.customThemes || {}) };
+  Object.entries(allThemes).forEach(([key, opt]) => {
     const btn = document.createElement('button');
     btn.className = 'hermes-button';
     btn.textContent = `${opt.emoji} ${opt.name}`;

--- a/hermes-extension/src/ui/setup.ts
+++ b/hermes-extension/src/ui/setup.ts
@@ -9,18 +9,32 @@ let dragHandle: HTMLDivElement | null = null;
 let dockMode: 'none' | 'top' | 'bottom' = 'none';
 const position = { top: 10, left: 10 };
 
-export function setupUI(root: HTMLElement = document.body, initialDock: 'none' | 'top' | 'bottom' = 'none') {
+export function setupUI(
+  root: HTMLElement = document.body,
+  initialDock: 'none' | 'top' | 'bottom' = 'none',
+  initialBunched = false,
+  initialPos?: { top: number | null; left: number | null }
+) {
   if (container) return container;
+
+  if (initialPos) {
+    if (typeof initialPos.top === 'number') position.top = initialPos.top;
+    if (typeof initialPos.left === 'number') position.left = initialPos.left;
+  }
 
   container = document.createElement('div');
   container.id = 'hermes-ui-container';
   container.style.cssText = 'position:fixed;top:10px;left:10px;display:flex;gap:4px;background:var(--hermes-bg);color:var(--hermes-text);padding:4px;border:1px solid var(--hermes-border);z-index:2147483647;';
+  container.style.top = `${position.top}px`;
+  container.style.left = `${position.left}px`;
   root.appendChild(container);
 
   minimized = document.createElement('div');
   minimized.id = 'hermes-minimized-container';
   minimized.textContent = '🛠️';
   minimized.style.cssText = 'display:none;position:fixed;top:10px;left:10px;cursor:pointer;padding:2px;z-index:2147483647;background:var(--hermes-bg);border:1px solid var(--hermes-border);color:var(--hermes-text);';
+  minimized.style.top = `${position.top}px`;
+  minimized.style.left = `${position.left}px`;
   minimized.onclick = () => toggleMinimizedUI(false);
   root.appendChild(minimized);
 
@@ -32,6 +46,8 @@ export function setupUI(root: HTMLElement = document.body, initialDock: 'none' |
   setupDragging(dragHandle);
 
   dockMode = initialDock;
+  isBunched = initialBunched;
+  if (isBunched && container) container.classList.add('hermes-bunched');
 
   const bunchBtn = document.createElement('button');
   bunchBtn.className = 'hermes-button';
@@ -40,6 +56,7 @@ export function setupUI(root: HTMLElement = document.body, initialDock: 'none' |
   bunchBtn.onclick = () => {
     isBunched = !isBunched;
     if (container) container.classList.toggle('hermes-bunched', isBunched);
+    saveDataToBackground('hermes_bunched_state_ext', isBunched);
   };
   container.appendChild(bunchBtn);
 
@@ -133,6 +150,7 @@ function setupDragging(handle: HTMLElement) {
   });
   document.addEventListener('mouseup', () => {
     dragging = false;
+    saveDataToBackground('hermes_position_ext', position);
   });
 }
 


### PR DESCRIPTION
## Summary
- style options UI with shared CSS variables
- apply user-selected theme via existing theme engine
- persist panel position and bunch state
- load theme menu from shared built-in & custom themes

## Testing
- `npm test`
- `cd ../server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890c9e0678c83329568c412cdcba983