### PR TITLE
feat: apply userscript themes and persist panel state

### DIFF
--- a/hermes-extension/options.html
+++ b/hermes-extension/options.html
@@ -4,8 +4,13 @@
     <meta charset="utf-8">
     <title>Hermes Options</title>
     <style>
-        body { font-family: Arial, sans-serif; padding: 20px; }
-        label { display:block; margin-top: 10px; }
+        body {
+            font-family: Arial, sans-serif;
+            padding: 20px;
+            background: var(--hermes-bg);
+            color: var(--hermes-text);
+        }
+        label { display: block; margin-top: 10px; }
         button { margin-top: 10px; }
     </style>
 </head>

--- a/hermes-extension/src/localCore.ts
+++ b/hermes-extension/src/localCore.ts
@@ -790,7 +790,12 @@ export class MacroEngine {
       if (!instant) {
         await new Promise(resolve => setTimeout(resolve, 100));
       }
-      
+
+      if (event.type === 'wait') {
+        await new Promise(res => setTimeout(res, event.duration || 0));
+        continue;
+      }
+
       const element = document.querySelector(event.selector);
       if (!element) continue;
 

--- a/hermes-extension/src/options.tsx
+++ b/hermes-extension/src/options.tsx
@@ -3,6 +3,23 @@ import { useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { t } from '../i18n.js';
 import { AffirmationToggle } from './productivity.tsx';
+import { applyTheme } from './theme.ts';
+import {
+  initMacros,
+  listMacros,
+  startRecording,
+  stopRecording,
+  playMacro,
+  deleteMacro,
+  importMacrosFromString,
+  exportMacros
+} from './macros.ts';
+import { refreshHotkeys } from './hotkeys.ts';
+import { toggleSchedule, initSchedule } from './schedule.ts';
+import { toggleScratchPad, initScratchPad } from './scratchPad.ts';
+import { toggleSnippets, initSnippets } from './snippets.ts';
+import { toggleTasks, initTasks } from './tasks.ts';
+import { toggleTimer } from './timer.ts';
 declare const chrome: any;
 
 const THEME_KEY = 'hermes_theme_ext';
@@ -17,6 +34,10 @@ function OptionsApp() {
   const [builtIn, setBuiltIn] = useState<Record<string, ThemeInfo>>({});
   const [custom, setCustom] = useState<Record<string, ThemeInfo>>({});
   const [current, setCurrent] = useState('dark');
+  const [macroNames, setMacroNames] = useState<string[]>([]);
+  const [isRecording, setIsRecording] = useState(false);
+  const [recordHotkey, setRecordHotkey] = useState('');
+  const [playHotkey, setPlayHotkey] = useState('');
 
   useEffect(() => {
     chrome.storage.local.get([THEME_KEY, CUSTOM_THEMES_KEY, 'hermes_built_in_themes'], data => {
@@ -27,6 +48,27 @@ function OptionsApp() {
       setCurrent(data[THEME_KEY] || 'dark');
     });
   }, []);
+
+  useEffect(() => {
+    if (chrome && chrome.runtime && chrome.runtime.sendMessage) {
+      initMacros().then(() => setMacroNames(listMacros()));
+      initSchedule();
+      initScratchPad();
+      initSnippets();
+      initTasks();
+      chrome.storage.local.get(['hermes_settings_v1_ext'], data => {
+        try {
+          const s = data.hermes_settings_v1_ext ? JSON.parse(data.hermes_settings_v1_ext) : {};
+          setRecordHotkey(s.recordHotkey || '');
+          setPlayHotkey(s.playMacroHotkey || '');
+        } catch {}
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    applyTheme(current);
+  }, [current]);
 
   const saveTheme = (val: string) => {
     setCurrent(val);
@@ -59,14 +101,71 @@ function OptionsApp() {
     reader.readAsText(files[0]);
   };
 
+  const exportMacroData = () => {
+    const data = exportMacros('json');
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'hermes-macros.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const importMacroData = (files: FileList | null) => {
+    if (!files || !files.length) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      importMacrosFromString(reader.result as string).then(ok => {
+        if (ok) setMacroNames(listMacros());
+      });
+    };
+    reader.readAsText(files[0]);
+  };
+
+  const handleRecord = () => { startRecording(); setIsRecording(true); };
+  const handleStop = () => { stopRecording(); setIsRecording(false); setMacroNames(listMacros()); };
+  const handlePlay = (name: string) => { playMacro(name); };
+  const handleDelete = (name: string) => { deleteMacro(name); setMacroNames(listMacros()); };
+
+  const saveHotkeys = () => {
+    chrome.storage.local.get(['hermes_settings_v1_ext'], data => {
+      let s: any = {};
+      try { s = data.hermes_settings_v1_ext ? JSON.parse(data.hermes_settings_v1_ext) : {}; } catch {}
+      s.recordHotkey = recordHotkey;
+      s.playMacroHotkey = playHotkey;
+      const json = JSON.stringify(s);
+      chrome.storage.local.set({ hermes_settings_v1_ext: json });
+      chrome.storage.sync.set({ hermes_settings_v1_ext: json }, () => {});
+      refreshHotkeys();
+    });
+  };
+
   const allThemes = { ...builtIn, ...custom };
 
   return (
-    <div>
+    <div
+      style={{
+        background: 'var(--hermes-panel-bg)',
+        color: 'var(--hermes-panel-text)',
+        padding: '10px',
+        border: '1px solid var(--hermes-panel-border)',
+        lineHeight: 'var(--hermes-line-height)'
+      }}
+    >
       <h1>{t('HERMES_OPTIONS')}</h1>
       <label>
         {t('THEME_LABEL')}
-        <select value={current} onChange={e => saveTheme(e.target.value)} id="themeSelect">
+        <select
+          value={current}
+          onChange={e => saveTheme(e.target.value)}
+          id="themeSelect"
+          style={{
+            background: 'var(--hermes-input-bg)',
+            color: 'var(--hermes-input-text)',
+            border: '1px solid var(--hermes-input-border)'
+          }}
+        >
           {Object.keys(allThemes).map(key => (
             <option key={key} value={key}>
               {allThemes[key].emoji} {allThemes[key].name}
@@ -75,11 +174,92 @@ function OptionsApp() {
         </select>
       </label>
       <div>
-        <button onClick={exportThemes} id="exportThemes">{t('EXPORT_THEMES')}</button>
-        <input id="importFile" type="file" accept="application/json" style={{ display: 'none' }} onChange={e => importThemes(e.target.files)} />
-        <button onClick={() => document.getElementById('importFile')!.click()} id="importThemes">{t('IMPORT_THEMES')}</button>
+        <button onClick={exportThemes} id="exportThemes" className="hermes-button">
+          {t('EXPORT_THEMES')}
+        </button>
+        <input
+          id="importFile"
+          type="file"
+          accept="application/json"
+          style={{ display: 'none' }}
+          onChange={e => importThemes(e.target.files)}
+        />
+        <button
+          onClick={() => document.getElementById('importFile')!.click()}
+          id="importThemes"
+          className="hermes-button"
+        >
+          {t('IMPORT_THEMES')}
+        </button>
       </div>
       <AffirmationToggle />
+      <h2>Macros</h2>
+      <div>
+        <button onClick={isRecording ? handleStop : handleRecord} className="hermes-button" id="recordMacro">
+          {isRecording ? t('STOP') : t('REC')}
+        </button>
+        <button onClick={() => toggleSchedule(true)} className="hermes-button">
+          {t('SCHEDULE')}
+        </button>
+        <button onClick={exportMacroData} id="exportMacros" className="hermes-button">
+          {t('EXPORT')}
+        </button>
+        <input
+          id="importMacroFile"
+          type="file"
+          accept="application/json"
+          style={{ display: 'none' }}
+          onChange={e => importMacroData(e.target.files)}
+        />
+        <button
+          onClick={() => document.getElementById('importMacroFile')!.click()}
+          id="importMacros"
+          className="hermes-button"
+        >
+          Import
+        </button>
+      </div>
+      <ul>
+        {macroNames.map(name => (
+          <li key={name} style={{ marginTop: '4px' }}>
+            {name}
+            <button onClick={() => handlePlay(name)} className="hermes-button" style={{ marginLeft: '4px' }}>
+              Play
+            </button>
+            <button onClick={() => handleDelete(name)} className="hermes-button" style={{ marginLeft: '4px' }}>
+              🗑️
+            </button>
+          </li>
+        ))}
+      </ul>
+      <div style={{ marginTop: '10px' }}>
+        <label style={{ marginRight: '10px' }}>
+          Record Hotkey:
+          <input value={recordHotkey} onChange={e => setRecordHotkey(e.target.value)} style={{ marginLeft: '4px' }} />
+        </label>
+        <label>
+          Play Hotkey:
+          <input value={playHotkey} onChange={e => setPlayHotkey(e.target.value)} style={{ marginLeft: '4px' }} />
+        </label>
+        <button onClick={saveHotkeys} className="hermes-button" style={{ marginLeft: '10px' }}>
+          Save
+        </button>
+      </div>
+      <h2 style={{ marginTop: '20px' }}>Tools</h2>
+      <div>
+        <button onClick={() => toggleScratchPad(true)} className="hermes-button">
+          {t('SCRATCH_PAD')}
+        </button>
+        <button onClick={() => toggleSnippets(true)} className="hermes-button" style={{ marginLeft: '4px' }}>
+          {t('SNIPPETS')}
+        </button>
+        <button onClick={() => toggleTasks(true)} className="hermes-button" style={{ marginLeft: '4px' }}>
+          {t('TASKS')}
+        </button>
+        <button onClick={() => toggleTimer(true)} className="hermes-button" style={{ marginLeft: '4px' }}>
+          {t('TIMER')}
+        </button>
+      </div>
     </div>
   );
 }

--- a/hermes-extension/src/ui.ts
+++ b/hermes-extension/src/ui.ts
@@ -3,7 +3,6 @@
 import { macroEngine, fillForm, getInitialData, saveDataToBackground, startSnowflakes, startLasers, startCube, stopEffects, setEffect, startLasersV14, startStrobeV14, startConfetti, startBubbles, startStrobe, getRoot } from './localCore.ts';
 import { getSettings } from './settings.ts';
 import { applyTheme } from './theme.ts';
-import { themeOptions } from './themeOptions.ts';
 import { loadSettings, toggleSettingsPanel } from './settings.ts';
 import { setupUI, toggleMinimizedUI } from './ui/setup.ts';
 import { createModal } from './ui/components.js';
@@ -94,7 +93,7 @@ export async function initUI() {
   shadowRoot = shadowHost.attachShadow({ mode: 'open' });
 
   // ----- UI ROOT -----
-  const container = setupUI(undefined, data.dockMode || 'none');
+  const container = setupUI(undefined, data.dockMode || 'none', data.isBunched, data.uiPosition);
   shadowRoot.appendChild(container);
 
   // ----- Panel Menus -----
@@ -393,12 +392,13 @@ function toggleMacroEditor(show: boolean, macroName?: string) {
       <select id="hermes-macro-edit-select" style="width:100%;margin-bottom:10px;"></select>
       <textarea id="hermes-macro-edit-text" style="width:100%;height:50vh;resize:vertical;font-family:monospace;padding:10px;box-sizing:border-box;"></textarea>
     `;
-    const buttonsHtml = `<button id="hermes-macro-edit-save">Save Marco</button>`;
+    const buttonsHtml = `<button id="hermes-macro-edit-save">Save Macro</button><button id="hermes-macro-edit-add-wait">Add Wait</button>`;
     panelContainer = createModal(shadowRoot, panelId, t('MACRO_EDITOR'), contentHtml, '700px', buttonsHtml);
     const panel = panelContainer.querySelector(`#${panelId}`) as HTMLElement;
     const selectEl = panel.querySelector('#hermes-macro-edit-select') as HTMLSelectElement;
     const textArea = panel.querySelector('#hermes-macro-edit-text') as HTMLTextAreaElement;
     const saveBtn = panel.querySelector('#hermes-macro-edit-save') as HTMLButtonElement;
+    const waitBtn = panel.querySelector('#hermes-macro-edit-add-wait') as HTMLButtonElement;
 
     const populate = () => {
       selectEl.innerHTML = macroEngine.list().map(n => `<option value="${n}">${n}</option>`).join('');
@@ -423,15 +423,27 @@ function toggleMacroEditor(show: boolean, macroName?: string) {
         (errContainer.querySelector('#err-ok-btn') as HTMLElement).onclick = () => errContainer.style.display = 'none';
       }
     };
+
+    waitBtn.onclick = () => {
+      try {
+        const arr = textArea.value ? JSON.parse(textArea.value) : [];
+        arr.push({ type: 'wait', duration: 1000 });
+        textArea.value = JSON.stringify(arr, null, 2);
+      } catch (e) {
+        alert('Invalid JSON in macro');
+      }
+    };
     populate();
   }
   if (panelContainer) panelContainer.style.display = show ? 'flex' : 'none';
 }
 
 // === Theme and Effects Panels ===
-function updateThemeSubmenu(menu: HTMLElement) {
+async function updateThemeSubmenu(menu: HTMLElement) {
   menu.innerHTML = '';
-  Object.entries(themeOptions).forEach(([key, opt]) => {
+  const data = await getInitialData();
+  const allThemes = { ...(data.builtInThemes || {}), ...(data.customThemes || {}) };
+  Object.entries(allThemes).forEach(([key, opt]) => {
     const btn = document.createElement('button');
     btn.className = 'hermes-button';
     btn.textContent = `${opt.emoji} ${opt.name}`;

--- a/hermes-extension/src/ui/setup.ts
+++ b/hermes-extension/src/ui/setup.ts
@@ -9,18 +9,32 @@ let dragHandle: HTMLDivElement | null = null;
 let dockMode: 'none' | 'top' | 'bottom' = 'none';
 const position = { top: 10, left: 10 };
 
-export function setupUI(root: HTMLElement = document.body, initialDock: 'none' | 'top' | 'bottom' = 'none') {
+export function setupUI(
+  root: HTMLElement = document.body,
+  initialDock: 'none' | 'top' | 'bottom' = 'none',
+  initialBunched = false,
+  initialPos?: { top: number | null; left: number | null }
+) {
   if (container) return container;
+
+  if (initialPos) {
+    if (typeof initialPos.top === 'number') position.top = initialPos.top;
+    if (typeof initialPos.left === 'number') position.left = initialPos.left;
+  }
 
   container = document.createElement('div');
   container.id = 'hermes-ui-container';
   container.style.cssText = 'position:fixed;top:10px;left:10px;display:flex;gap:4px;background:var(--hermes-bg);color:var(--hermes-text);padding:4px;border:1px solid var(--hermes-border);z-index:2147483647;';
+  container.style.top = `${position.top}px`;
+  container.style.left = `${position.left}px`;
   root.appendChild(container);
 
   minimized = document.createElement('div');
   minimized.id = 'hermes-minimized-container';
   minimized.textContent = '🛠️';
   minimized.style.cssText = 'display:none;position:fixed;top:10px;left:10px;cursor:pointer;padding:2px;z-index:2147483647;background:var(--hermes-bg);border:1px solid var(--hermes-border);color:var(--hermes-text);';
+  minimized.style.top = `${position.top}px`;
+  minimized.style.left = `${position.left}px`;
   minimized.onclick = () => toggleMinimizedUI(false);
   root.appendChild(minimized);
 
@@ -32,6 +46,8 @@ export function setupUI(root: HTMLElement = document.body, initialDock: 'none' |
   setupDragging(dragHandle);
 
   dockMode = initialDock;
+  isBunched = initialBunched;
+  if (isBunched && container) container.classList.add('hermes-bunched');
 
   const bunchBtn = document.createElement('button');
   bunchBtn.className = 'hermes-button';
@@ -40,6 +56,7 @@ export function setupUI(root: HTMLElement = document.body, initialDock: 'none' |
   bunchBtn.onclick = () => {
     isBunched = !isBunched;
     if (container) container.classList.toggle('hermes-bunched', isBunched);
+    saveDataToBackground('hermes_bunched_state_ext', isBunched);
   };
   container.appendChild(bunchBtn);
 
@@ -133,6 +150,7 @@ function setupDragging(handle: HTMLElement) {
   });
   document.addEventListener('mouseup', () => {
     dragging = false;
+    saveDataToBackground('hermes_position_ext', position);
   });
 }
 


### PR DESCRIPTION
## Summary
- style options UI with shared CSS variables
- apply user-selected theme via existing theme engine
- persist panel position and bunch state
- load theme menu from shared built-in & custom themes
- manage macros from options page with recording, import/export, scheduler access and hotkey settings
- expose scratchpad, snippets, tasks and timer tools in options

## Testing
- `npm test`
- `cd ../server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890c9e0678c83329568c412cdcba983