### PR TITLE
feat: improve accessibility with ARIA and narrator

### DIFF
--- a/hermes-extension/i18n.js
+++ b/hermes-extension/i18n.js
@@ -72,7 +72,16 @@ export const translations = {
     DOMAIN_CONFIGS: 'Domain Configs',
     DOMAIN: 'Domain',
     ONBOARD_TITLE: 'Welcome to Hermes',
-    ONBOARD_MSG: 'Use the toolbar to fill forms and record macros. Open settings with the gear icon.'
+    ONBOARD_MSG: 'Use the toolbar to fill forms and record macros. Open settings with the gear icon.',
+    ENABLE_NARRATOR: 'Enable Narrator',
+    NARRATOR_ENABLED: 'Narrator enabled',
+    NARRATOR_DISABLED: 'Narrator disabled',
+    HERMES_TOOLBAR: 'Hermes toolbar',
+    OPEN_TOOLBAR: 'Open Hermes toolbar',
+    DRAG_TOOLBAR: 'Drag toolbar',
+    MINIMIZE: 'Minimize',
+    TOOLBAR_MINIMIZED: 'Toolbar minimized',
+    TOOLBAR_RESTORED: 'Toolbar restored'
   },
   es: {
     HERMES_OPTIONS: 'Opciones de Hermes',
@@ -147,7 +156,16 @@ export const translations = {
     DOMAIN_CONFIGS: 'Configs de Dominio',
     DOMAIN: 'Dominio',
     ONBOARD_TITLE: 'Bienvenido a Hermes',
-    ONBOARD_MSG: 'Usa la barra para grabar macros o rellenar formularios. Abre ajustes con el icono de engranaje.'
+    ONBOARD_MSG: 'Usa la barra para grabar macros o rellenar formularios. Abre ajustes con el icono de engranaje.',
+    ENABLE_NARRATOR: 'Activar narrador',
+    NARRATOR_ENABLED: 'Narrador activado',
+    NARRATOR_DISABLED: 'Narrador desactivado',
+    HERMES_TOOLBAR: 'Barra de Hermes',
+    OPEN_TOOLBAR: 'Abrir barra de Hermes',
+    DRAG_TOOLBAR: 'Mover barra',
+    MINIMIZE: 'Minimizar',
+    TOOLBAR_MINIMIZED: 'Barra minimizada',
+    TOOLBAR_RESTORED: 'Barra restaurada'
   }
 };
 

--- a/hermes-extension/src/narrator.tsx
+++ b/hermes-extension/src/narrator.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from 'react';
+import { t } from '../i18n.js';
+
+declare const chrome: any;
+
+const NARRATOR_KEY = 'hermes_narrator_enabled_ext';
+let enabled = false;
+
+function speak(text: string) {
+  if (!enabled || !text || typeof window === 'undefined' || !('speechSynthesis' in window)) return;
+  const utter = new SpeechSynthesisUtterance(text);
+  window.speechSynthesis.speak(utter);
+}
+
+function onFocus(e: FocusEvent) {
+  const el = e.target as HTMLElement;
+  if (!el) return;
+  const label = el.getAttribute('aria-label') || el.getAttribute('title') || el.textContent || '';
+  if (label) speak(label.trim());
+}
+
+export function initNarrator() {
+  if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.local) {
+    chrome.storage.local.get([NARRATOR_KEY], res => {
+      enabled = !!res[NARRATOR_KEY];
+      if (enabled) document.addEventListener('focusin', onFocus);
+    });
+  }
+}
+
+export function setNarrator(val: boolean) {
+  enabled = val;
+  if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.local) {
+    chrome.storage.local.set({ [NARRATOR_KEY]: val });
+  }
+  if (enabled) document.addEventListener('focusin', onFocus);
+  else document.removeEventListener('focusin', onFocus);
+}
+
+export function NarratorToggle() {
+  const [on, setOn] = useState(false);
+  useEffect(() => {
+    if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.local) {
+      chrome.storage.local.get([NARRATOR_KEY], res => setOn(!!res[NARRATOR_KEY]));
+    }
+  }, []);
+  const handle = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.checked;
+    setOn(val);
+    setNarrator(val);
+    if (val) speak(t('NARRATOR_ENABLED'));
+    else speak(t('NARRATOR_DISABLED'));
+  };
+  return (
+    <label>
+      <input type="checkbox" checked={on} onChange={handle} /> {t('ENABLE_NARRATOR')}
+    </label>
+  );
+}
+
+export { speak };

--- a/hermes-extension/src/options.tsx
+++ b/hermes-extension/src/options.tsx
@@ -5,6 +5,7 @@ import { t } from '../i18n.js';
 import { AffirmationToggle } from './productivity.tsx';
 import { applyTheme } from './theme.ts';
 import { initHighContrast, setHighContrast } from './highContrast.ts';
+import { NarratorToggle, initNarrator } from './narrator.tsx';
 import {
   initMacros,
   listMacros,
@@ -70,6 +71,10 @@ function OptionsApp() {
       setCustom(customThemes);
       setCurrent(data[THEME_KEY] || 'dark');
     });
+  }, []);
+
+  useEffect(() => {
+    initNarrator();
   }, []);
 
   useEffect(() => {
@@ -350,6 +355,7 @@ function OptionsApp() {
         <input type="checkbox" checked={highContrast} onChange={toggleHighContrast} /> {t('HIGH_CONTRAST_MODE')}
       </label>
       <AffirmationToggle />
+      <NarratorToggle />
       <h2>Macros</h2>
       <div>
         <button onClick={isRecording ? handleStop : handleRecord} className="hermes-button" id="recordMacro">

--- a/hermes-extension/src/ui.ts
+++ b/hermes-extension/src/ui.ts
@@ -11,6 +11,7 @@ import { isAllowed, loadWhitelist, saveWhitelist } from './allowlist.ts';
 import { t } from '../i18n.js';
 import { initializeBackendAPI } from './backendConfig.ts';
 import { initHighContrast } from './highContrast.ts';
+import { initNarrator } from './narrator.tsx';
 
 // Lazy load heavy features
 const lazyLoadTrainer = () => import('./trainer.ts').then(m => m.runHeuristicTrainerSession);
@@ -86,6 +87,7 @@ export async function initUI() {
 
   // Initialize backend API connection to Recreated folder
   await initializeBackendAPI();
+  initNarrator();
 
   // ----- SHADOW DOM SETUP -----
   shadowHost = document.createElement('div');

--- a/hermes-extension/src/ui/components.js
+++ b/hermes-extension/src/ui/components.js
@@ -1,5 +1,6 @@
 import { saveDataToBackground } from '../storage/index.ts';
 import { t } from '../../i18n.js';
+import { speak } from '../narrator.tsx';
 
 export function getPanelBaseStyle() {
   return `display:none;position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);width:90%;max-width:500px;max-height:80vh;background:var(--hermes-panel-bg, #FFF);border:1px solid var(--hermes-panel-border, #CCC);border-radius:8px;box-shadow:0 5px 15px rgba(0,0,0,0.3);padding:20px;z-index:2147483647;font-family:sans-serif;color:var(--hermes-panel-text, #000);overflow-y:auto;box-sizing:border-box;`;
@@ -13,16 +14,20 @@ export function createModal(root, id, title, contentHtml, maxWidth = '600px', cu
   panel.id = id;
   panel.className = 'hermes-panel';
   panel.style.cssText = getPanelBaseStyle() + `max-width: ${maxWidth};`;
+  panel.setAttribute('role', 'dialog');
+  panel.setAttribute('aria-modal', 'true');
+  panel.tabIndex = -1;
 
-  let buttonsBlock = `<button class="hermes-panel-close hermes-button">${t('CLOSE')}</button>`;
+  let buttonsBlock = `<button class="hermes-panel-close hermes-button" aria-label="${t('CLOSE')}">${t('CLOSE')}</button>`;
   if (customButtonsHtml) {
     buttonsBlock = customButtonsHtml.replace(/<button/g, '<button class="hermes-button"') + buttonsBlock;
   }
 
   panel.innerHTML = `
-    <h2 class="hermes-panel-title">${title}</h2>
+    <h2 id="${id}-title" class="hermes-panel-title">${title}</h2>
     <div class="hermes-panel-content">${contentHtml}</div>
     <div class="hermes-panel-buttons">${buttonsBlock}</div>`;
+  panel.setAttribute('aria-labelledby', `${id}-title`);
 
   if (root) {
     if (root instanceof ShadowRoot) {
@@ -37,6 +42,8 @@ export function createModal(root, id, title, contentHtml, maxWidth = '600px', cu
         saveDataToBackground('hermes_help_panel_state_ext', false).catch(e => console.error('Hermes CS: Failed to save help panel closed state', e));
       }
     });
+    speak(title);
+    panel.focus();
   } else {
     console.error('Hermes CS: shadowRoot not available to create modal:', id);
   }

--- a/hermes-extension/src/ui/setup.ts
+++ b/hermes-extension/src/ui/setup.ts
@@ -1,5 +1,6 @@
 import { t } from '../../i18n.js';
 import { saveDataToBackground } from '../storage/index.ts';
+import { speak } from '../narrator.tsx';
 
 let container: HTMLDivElement | null = null;
 let minimized: HTMLDivElement | null = null;
@@ -25,6 +26,8 @@ export function setupUI(
   container = document.createElement('div');
   container.id = 'hermes-ui-container';
   container.style.cssText = 'position:fixed;top:10px;left:10px;display:flex;gap:4px;background:var(--hermes-bg);color:var(--hermes-text);padding:4px;border:1px solid var(--hermes-border);z-index:2147483647;';
+  container.setAttribute('role', 'toolbar');
+  container.setAttribute('aria-label', t('HERMES_TOOLBAR'));
   container.style.top = `${position.top}px`;
   container.style.left = `${position.left}px`;
   root.appendChild(container);
@@ -35,13 +38,25 @@ export function setupUI(
   minimized.style.cssText = 'display:none;position:fixed;top:10px;left:10px;cursor:pointer;padding:2px;z-index:2147483647;background:var(--hermes-bg);border:1px solid var(--hermes-border);color:var(--hermes-text);';
   minimized.style.top = `${position.top}px`;
   minimized.style.left = `${position.left}px`;
+  minimized.setAttribute('role', 'button');
+  minimized.setAttribute('tabindex', '0');
+  minimized.setAttribute('aria-label', t('OPEN_TOOLBAR'));
   minimized.onclick = () => toggleMinimizedUI(false);
+  minimized.onkeydown = (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      toggleMinimizedUI(false);
+    }
+  };
   root.appendChild(minimized);
 
   dragHandle = document.createElement('div');
   dragHandle.id = 'hermes-drag-handle';
   dragHandle.textContent = '☰';
   dragHandle.style.cssText = 'cursor:move;user-select:none;padding:0 4px;';
+  dragHandle.setAttribute('role', 'button');
+  dragHandle.setAttribute('aria-label', t('DRAG_TOOLBAR'));
+  dragHandle.tabIndex = 0;
   container.appendChild(dragHandle);
   setupDragging(dragHandle);
 
@@ -53,6 +68,7 @@ export function setupUI(
   bunchBtn.className = 'hermes-button';
   bunchBtn.id = 'hermes-bunch-button';
   bunchBtn.textContent = t('BUNCH');
+  bunchBtn.setAttribute('aria-label', t('BUNCH'));
   bunchBtn.onclick = () => {
     isBunched = !isBunched;
     if (container) container.classList.toggle('hermes-bunched', isBunched);
@@ -64,6 +80,8 @@ export function setupUI(
   minBtn.className = 'hermes-button';
   minBtn.id = 'hermes-minimize-button';
   minBtn.textContent = '_';
+  minBtn.setAttribute('aria-label', t('MINIMIZE'));
+  minBtn.title = t('MINIMIZE');
   minBtn.onclick = () => toggleMinimizedUI(true);
   container.appendChild(minBtn);
 
@@ -87,6 +105,8 @@ export function setupUI(
     const b = document.createElement('button');
     b.className = 'hermes-button';
     b.textContent = d.label;
+    b.setAttribute('aria-label', `Snap ${d.edge.replace(/-/g, ' ')}`);
+    b.title = `Snap ${d.edge.replace(/-/g, ' ')}`;
     b.onclick = () => {
       if (d.edge === 'dock-top') dockToPage('top');
       else if (d.edge === 'dock-bottom') dockToPage('bottom');
@@ -106,6 +126,7 @@ export function toggleMinimizedUI(minimize: boolean) {
   isMinimized = minimize;
   container.style.display = minimize ? 'none' : 'flex';
   minimized.style.display = minimize ? 'flex' : 'none';
+  speak(minimize ? t('TOOLBAR_MINIMIZED') : t('TOOLBAR_RESTORED'));
   if (!minimize) {
     container.style.left = `${position.left}px`;
     container.style.top = `${position.top}px`;


### PR DESCRIPTION
## Summary
- add ARIA roles and labels across extension UI components
- introduce speech-based Narrator toggle using browser TTS
- wire up initialization and localization for new accessibility features

## Testing
- `cd hermes-extension && npm test`
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890e8dc9b4883329c730e6b338372de