### PR TITLE
feat: add customer data helpers to SaaS connectors

### DIFF
--- a/hermes-extension/src/backendConfig.ts
+++ b/hermes-extension/src/backendConfig.ts
@@ -191,6 +191,25 @@ export class BackendAPI {
     }
   }
 
+  // Get customer data from a SaaS connector
+  async getCustomerData(
+    platform: string,
+    query: Record<string, unknown> = {}
+  ): Promise<any> {
+    const params = new URLSearchParams(query as Record<string, string>);
+    const qs = params.toString();
+    const url = `${this.config.endpoints.connectors}/${platform}/customer`;
+    return this.request(qs ? `${url}?${qs}` : url);
+  }
+
+  // Update customer data in a SaaS connector
+  async updateCustomerData(platform: string, data: any): Promise<void> {
+    await this.request(`${this.config.endpoints.connectors}/${platform}/customer`, {
+      method: 'PUT',
+      body: JSON.stringify(data)
+    });
+  }
+
   // Sync with GitHub repository
   async syncWithGitHub(repoConfig: any): Promise<void> {
     await this.request(this.config.endpoints.sync, {

--- a/hermes-extension/test/backendConfig.test.ts
+++ b/hermes-extension/test/backendConfig.test.ts
@@ -1,0 +1,20 @@
+import { BackendAPI } from '../src/backendConfig.ts';
+
+describe('BackendAPI customer data methods', () => {
+  test('getCustomerData requests customer endpoint with query', async () => {
+    const api = new BackendAPI();
+    const requestSpy = jest.spyOn(api as any, 'request').mockResolvedValue({});
+    await api.getCustomerData('salesforce', { id: '123' });
+    expect(requestSpy).toHaveBeenCalledWith('/api/v1/connectors/salesforce/customer?id=123');
+  });
+
+  test('updateCustomerData sends PUT with payload', async () => {
+    const api = new BackendAPI();
+    const requestSpy = jest.spyOn(api as any, 'request').mockResolvedValue({});
+    await api.updateCustomerData('bmcHelix', { name: 'Alice' });
+    expect(requestSpy).toHaveBeenCalledWith('/api/v1/connectors/bmcHelix/customer', {
+      method: 'PUT',
+      body: JSON.stringify({ name: 'Alice' })
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extend backend API with getCustomerData and updateCustomerData for SaaS connectors
- add tests for customer data helpers

## Testing
- `npm test` (hermes-extension)
- `npm test` (server)


------
https://chatgpt.com/codex/tasks/task_e_6890faa0ed9c8332b2600a42f4250586