### PR TITLE
docs: add data source management and runtime config reload

### DIFF
--- a/docs/data-source-management.md
+++ b/docs/data-source-management.md
@@ -1,0 +1,24 @@
+# Data Source Management
+
+Use backend configuration to control SaaS data sources. Connectors are stored under the `saas` key of `hermes_backend_config`.
+
+## Add a Connector
+1. Open the extension Options page.
+2. Enter a new connector name and configure its fields.
+3. Save to store the configuration in `chrome.storage`.
+4. The extension reloads connector mappings immediately.
+
+See [`sample-connector.json`](./sample-connector.json) for the JSON structure.
+
+## Remove a Connector
+1. Open the Options page.
+2. Use the **Remove** button next to the connector.
+3. Save the changes. The connector and its mapping are removed at runtime.
+
+## Update Mapping Files
+Connector mappings translate profile fields to API fields.
+
+1. Edit the `mapping` object for a connector in the Options page or in a JSON file.
+2. Save the configuration. The extension reloads mappings without requiring a restart.
+
+Default connectors are listed in [`default-connectors.json`](./default-connectors.json).

--- a/docs/default-connectors.json
+++ b/docs/default-connectors.json
@@ -1,0 +1,26 @@
+{
+  "salesforce": {
+    "baseUrl": "",
+    "apiVersion": "v57.0",
+    "authEndpoint": "/services/oauth2/token",
+    "dataRoute": "/services/data",
+    "mapping": {},
+    "credentials": {
+      "clientId": "",
+      "clientSecret": "",
+      "username": "",
+      "password": ""
+    }
+  },
+  "bmcHelix": {
+    "baseUrl": "",
+    "apiVersion": "v1",
+    "authEndpoint": "/api/jwt/login",
+    "dataRoute": "/api/arsys/v1",
+    "mapping": {},
+    "credentials": {
+      "username": "",
+      "password": ""
+    }
+  }
+}

--- a/docs/sample-connector.json
+++ b/docs/sample-connector.json
@@ -1,0 +1,16 @@
+{
+  "exampleConnector": {
+    "baseUrl": "https://api.example.com",
+    "apiVersion": "v1",
+    "authEndpoint": "/oauth/token",
+    "dataRoute": "/data",
+    "mapping": {
+      "firstName": "contact.first_name",
+      "lastName": "contact.last_name"
+    },
+    "credentials": {
+      "clientId": "CLIENT_ID",
+      "clientSecret": "CLIENT_SECRET"
+    }
+  }
+}

--- a/hermes-extension/src/backendConfig.ts
+++ b/hermes-extension/src/backendConfig.ts
@@ -376,6 +376,18 @@ export class BackendAPI {
 // Global backend API instance
 export const backendAPI = new BackendAPI();
 
+// Reload backend configuration at runtime when storage changes
+if (typeof chrome !== 'undefined' && chrome.storage) {
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area === 'local' && changes.hermes_backend_config) {
+      const newCfg: BackendConfig =
+        changes.hermes_backend_config.newValue || DEFAULT_BACKEND_CONFIG;
+      Object.assign(backendAPI, new BackendAPI(newCfg));
+      backendAPI.loadConnectorTokens();
+    }
+  });
+}
+
 // Load backend configuration from storage
 export async function loadBackendConfig(): Promise<BackendConfig> {
   try {


### PR DESCRIPTION
## Summary
- document how to manage connectors and mappings with sample JSON and default connector listings
- reload extension mappings when backend configuration changes

## Testing
- `npm test` in `hermes-extension`
- `npm test` in `server`


------
https://chatgpt.com/codex/tasks/task_e_68910300798083329cc2aa1db479e193