### PR TITLE
chore: remove unused React index

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,8 +242,7 @@ the repo root.
 ```
 packages/
   core/        <- reusable form filler, macro engine and effects modules
-hermes-extension/       <- MV3 extension source
-hermes-extension/hermes-react-refactor/ <- React prototype
+hermes-extension/       <- MV3 extension source (React UI in src/react/)
 server/        <- Express API for macro automation
 ```
 

--- a/hermes-extension/src/react/index.tsx
+++ b/hermes-extension/src/react/index.tsx
@@ -1,5 +1,0 @@
-// hermes-react-refactor/src/index.tsx
-
-import './index.css';
-// Importing the content script triggers the UI injection 👍
-import './content';


### PR DESCRIPTION
## Summary
- drop stale `src/react/index.tsx` entry
- document React UI location in README

## Testing
- `npm test` (hermes-extension)
- `npm test` (server)


------
https://chatgpt.com/codex/tasks/task_e_689237d798d483328198c3d911f282bf