### PR TITLE
refactor: centralize shared React components

### DIFF
--- a/hermes-extension/src/react/App.tsx
+++ b/hermes-extension/src/react/App.tsx
@@ -3,9 +3,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { RootState, AppDispatch } from './store';
-import { SettingsPanel } from './components/SettingsPanel';
-import MacroPanel from './components/MacroPanel';
-import { TrainerPanel } from './components/TrainerPanel';
+import { MacroPanel, SettingsPanel, TrainerPanel } from './lib/components';
 import { useDraggable } from './hooks/useDraggable';
 import { macroEngine, fillForm } from '@hermes/core';
 import { startHeuristicTraining } from './services/trainerService';

--- a/hermes-extension/src/react/lib/components/AffirmationToggle.tsx
+++ b/hermes-extension/src/react/lib/components/AffirmationToggle.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { getAffirmationState, setAffirmations } from '../services/affirmationService';
+import { getAffirmationState, setAffirmations } from '../../services/affirmationService';
 
 export const AffirmationToggle: React.FC = () => {
   const [enabled, setEnabled] = useState(false);

--- a/hermes-extension/src/react/lib/components/MacroPanel.tsx
+++ b/hermes-extension/src/react/lib/components/MacroPanel.tsx
@@ -1,18 +1,18 @@
-// src/react/components/MacroPanel.tsx
+// src/react/lib/components/MacroPanel.tsx
 
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { RootState, AppDispatch } from '../store';
-import { deleteMacro, renameMacro, saveMacros } from '../store/macrosSlice';
-import { macroEngine } from '@hermes/core';
+import { RootState, AppDispatch } from '../../store';
+import { deleteMacro, renameMacro, saveMacros } from '../../store/macrosSlice';
 
 const MacroPanel: React.FC = () => {
   const dispatch = useDispatch<AppDispatch>();
   const { macros } = useSelector((state: RootState) => state.macros);
 
-  const handlePlay = (name: string) => {
+  const handlePlay = async (name: string) => {
     // Play the macro by name. The macro engine manages its own store so we
     // simply call play with the macro name. 🎬
+    const { macroEngine } = await import('@hermes/core');
     macroEngine.play(name);
   };
 

--- a/hermes-extension/src/react/lib/components/SettingsPanel.tsx
+++ b/hermes-extension/src/react/lib/components/SettingsPanel.tsx
@@ -1,12 +1,12 @@
-// src/react/components/SettingsPanel.tsx
+// src/react/lib/components/SettingsPanel.tsx
 
 import React, { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { RootState, AppDispatch } from '../store';
-import { saveSettings, updateSettings } from '../store/settingsSlice';
+import { RootState, AppDispatch } from '../../store';
+import { saveSettings, updateSettings } from '../../store/settingsSlice';
 import { ThemeSelector } from './ThemeSelector';
 import { AffirmationToggle } from './AffirmationToggle';
-import { defaultSettings } from '../config/defaultSettings';
+import { defaultSettings } from '../../config/defaultSettings';
 
 interface SettingsPanelProps {
   onClose: () => void;

--- a/hermes-extension/src/react/lib/components/ThemeSelector.tsx
+++ b/hermes-extension/src/react/lib/components/ThemeSelector.tsx
@@ -1,10 +1,10 @@
-// src/react/components/ThemeSelector.tsx
+// src/react/lib/components/ThemeSelector.tsx
 
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { RootState, AppDispatch } from '../store';
-import { setTheme, saveTheme } from '../store/themeSlice';
-import { getThemeOptions } from '../themes/theme';
+import { RootState, AppDispatch } from '../../store';
+import { setTheme, saveTheme } from '../../store/themeSlice';
+import { getThemeOptions } from '../../themes/theme';
 
 export const ThemeSelector: React.FC = () => {
   const dispatch = useDispatch<AppDispatch>();

--- a/hermes-extension/src/react/lib/components/TrainerPanel.tsx
+++ b/hermes-extension/src/react/lib/components/TrainerPanel.tsx
@@ -1,10 +1,10 @@
-// src/react/components/TrainerPanel.tsx
+// src/react/lib/components/TrainerPanel.tsx
 
 import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { AppDispatch } from '../store';
+import { AppDispatch } from '../../store';
 import { SkippedField, ProfileData } from '@hermes/core';
-import { updateProfile, saveProfile } from '../store/profileSlice';
+import { updateProfile, saveProfile } from '../../store/profileSlice';
 
 interface TrainerPanelProps {
   skippedFields: SkippedField[];

--- a/hermes-extension/src/react/lib/components/index.ts
+++ b/hermes-extension/src/react/lib/components/index.ts
@@ -1,0 +1,5 @@
+export { AffirmationToggle } from './AffirmationToggle';
+export { default as MacroPanel } from './MacroPanel';
+export { SettingsPanel } from './SettingsPanel';
+export { ThemeSelector } from './ThemeSelector';
+export { TrainerPanel } from './TrainerPanel';

--- a/hermes-extension/src/react/options.tsx
+++ b/hermes-extension/src/react/options.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
-import { AffirmationToggle } from './components/AffirmationToggle';
+import { AffirmationToggle } from './lib/components';
 import { themeOptions } from './themes/themeOptions';
 
 declare const chrome: any;


### PR DESCRIPTION
## Summary
- consolidate reusable React components under a new `lib/components` library with barrel exports
- adjust feature panels to consume the shared component exports
- lazily load the macro engine inside `MacroPanel` to avoid unnecessary dependency loading

## Testing
- `cd hermes-extension && npm test`
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68923ff9a8508332978f24ea6717469c