### PR TITLE
feat: translate legacy settings to new structure

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,19 @@
+# Migration Guide
+
+To keep Hermes humming along nicely, a few settings were renamed.
+Stored settings are translated automatically on load, but here's the cheat sheet
+for reference:
+
+| Legacy name | New name |
+| --- | --- |
+| `recordHotkey` | `hotkeys.record` |
+| `playMacroHotkey` | `hotkeys.play` |
+| `macro.useCoords` | `macro.useCoordinateFallback` |
+| `macro.recordMouse` | `macro.recordMouseMoves` |
+| `macro.relativeCoords` | `macro.relativeCoordinates` |
+| `macro.similarity` | `macro.similarityThreshold` |
+| `effects.lasers` | `effects.lasersV13` |
+| `effects.snow`, `effects.snowflakes` | `effects.snowflakesV13` |
+| `effects.strobe` | `effects.strobeV13` |
+
+Future migrations can add new entries here so upgrades stay smooth. 😄

--- a/hermes-extension/src/hotkeys.ts
+++ b/hermes-extension/src/hotkeys.ts
@@ -1,6 +1,14 @@
 import { startRecording, stopRecording, playSelectedMacro, recording } from './macros.ts';
 import { getSettings } from './settings.ts';
 
+// Legacy -> new hotkey setting names 🎹
+// Allows us to keep supporting older stored settings while
+// moving toward the new structured `hotkeys` block.
+export const legacyHotkeyNameMap: Record<string, string> = {
+  recordHotkey: 'record',
+  playMacroHotkey: 'play',
+} as const;
+
 interface Hotkey {
   key: string;
   ctrl: boolean;
@@ -47,8 +55,14 @@ function handle(e: KeyboardEvent) {
 
 function updateFromSettings() {
   const s = getSettings();
-  recordHotkey = parseHotkey(String(s.recordHotkey || 'Ctrl+Shift+R'));
-  playHotkey = parseHotkey(String(s.playMacroHotkey || 'Ctrl+Shift+P'));
+  const hotkeyBlock = (s as any).hotkeys || {};
+
+  // Read new names first, fall back to legacy ones 😊
+  const record = hotkeyBlock[legacyHotkeyNameMap.recordHotkey] || s.recordHotkey;
+  const play = hotkeyBlock[legacyHotkeyNameMap.playMacroHotkey] || s.playMacroHotkey;
+
+  recordHotkey = parseHotkey(String(record || 'Ctrl+Shift+R'));
+  playHotkey = parseHotkey(String(play || 'Ctrl+Shift+P'));
 }
 
 export function initHotkeys() {

--- a/hermes-extension/src/react/config/defaultSettings.ts
+++ b/hermes-extension/src/react/config/defaultSettings.ts
@@ -98,5 +98,26 @@ export const defaultSettings = {
     "_comment_useCoordinateFallback": "When elements can't be found by selector, use recorded x/y coordinates or DOM path.",
     "similarityThreshold": 0.5,
     "_comment_similarityThreshold": "Minimum similarity score (0-1) for heuristic field matching. Default: 0.5."
+  },
+  "_comment_hotkeys": "Keyboard shortcuts for macro recording and playback.",
+  "hotkeys": {
+    "record": "Ctrl+Shift+R",
+    "_comment_record": "Key combo to start/stop recording (e.g., Ctrl+Shift+R).",
+    "play": "Ctrl+Shift+P",
+    "_comment_play": "Key combo to play the last macro (e.g., Ctrl+Shift+P)."
   }
+} as const;
+
+// Mapping of legacy setting names to their shiny new counterparts ✨
+export const legacySettingNameMap: Record<string, string> = {
+  'recordHotkey': 'hotkeys.record',
+  'playMacroHotkey': 'hotkeys.play',
+  'macro.useCoords': 'macro.useCoordinateFallback',
+  'macro.recordMouse': 'macro.recordMouseMoves',
+  'macro.relativeCoords': 'macro.relativeCoordinates',
+  'macro.similarity': 'macro.similarityThreshold',
+  'effects.lasers': 'effects.lasersV13',
+  'effects.snow': 'effects.snowflakesV13',
+  'effects.snowflakes': 'effects.snowflakesV13',
+  'effects.strobe': 'effects.strobeV13',
 } as const;

--- a/hermes-extension/src/react/store/settingsSlice.ts
+++ b/hermes-extension/src/react/store/settingsSlice.ts
@@ -1,7 +1,7 @@
 // src/react/store/settingsSlice.ts
 
 import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
-import { defaultSettings } from '../config/defaultSettings';
+import { defaultSettings, legacySettingNameMap } from '../config/defaultSettings';
 import { saveDataToBackground, getInitialData } from '../services/storageService';
 
 export interface SettingsState {
@@ -16,7 +16,40 @@ const initialState: SettingsState = {
 
 export const loadSettings = createAsyncThunk('settings/load', async () => {
   const data = await getInitialData();
-  return { ...defaultSettings, ...(data.settings || {}) };
+  const stored = data.settings || {};
+
+  // Translate legacy settings to the spiffy new structure 🛠️
+  const translate = (settings: any) => {
+    const result = { ...settings };
+    const moveValue = (from: string, to: string) => {
+      const fromParts = from.split('.');
+      const toParts = to.split('.');
+
+      let fromObj = result;
+      for (let i = 0; i < fromParts.length - 1; i++) {
+        fromObj = fromObj?.[fromParts[i]];
+        if (!fromObj) return;
+      }
+      const val = fromObj[fromParts[fromParts.length - 1]];
+      if (val === undefined) return;
+
+      let toObj = result;
+      for (let i = 0; i < toParts.length - 1; i++) {
+        if (typeof toObj[toParts[i]] !== 'object' || toObj[toParts[i]] === null) {
+          toObj[toParts[i]] = {};
+        }
+        toObj = toObj[toParts[i]];
+      }
+      toObj[toParts[toParts.length - 1]] = val;
+      delete fromObj[fromParts[fromParts.length - 1]];
+    };
+
+    Object.entries(legacySettingNameMap).forEach(([oldName, newName]) => moveValue(oldName, newName));
+    return result;
+  };
+
+  const translated = translate(stored);
+  return { ...defaultSettings, ...translated };
 });
 
 export const saveSettings = createAsyncThunk('settings/save', async (settings: any) => {


### PR DESCRIPTION
## Summary
- map legacy hotkey names to new structured block
- translate stored settings into updated schema before Redux load
- document renamed settings for future migrations

## Testing
- `npm test` (hermes-extension)
- `npm test` (server)


------
https://chatgpt.com/codex/tasks/task_e_68923ffb3a9c8332a071b264c2e15b9e