### PR TITLE
feat: add build flags and hosting docs

### DIFF
--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -1,0 +1,15 @@
+# Hosting Plugin Manifests and Skins
+
+Serve your plugin goodies from GitHub Pages or Netlify so Hermes can fetch them easily. 😄
+
+## GitHub Pages
+1. Place manifest or skin files in a public repo.
+2. Under **Settings > Pages**, choose the branch and folder to publish.
+3. The files become available at `https://<user>.github.io/<repo>/<file>`.
+
+## Netlify
+1. Create a new site from your repository.
+2. Set the publish directory to the folder with manifest/skin files.
+3. Deploy and use the generated URL to reference your assets.
+
+Both services require public access for Hermes to load the assets. ✅

--- a/docs/serverless-setup.md
+++ b/docs/serverless-setup.md
@@ -1,0 +1,28 @@
+# Serverless Setup
+
+Use Firebase or Supabase to power Hermes without managing your own servers. 🚀
+
+## Firebase Example
+```js
+import { initializeApp } from 'firebase/app';
+
+const firebaseConfig = {
+  apiKey: 'YOUR_API_KEY',
+  authDomain: 'YOUR_AUTH_DOMAIN',
+  projectId: 'YOUR_PROJECT_ID'
+};
+
+const app = initializeApp(firebaseConfig);
+```
+
+## Supabase Example
+```js
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = 'https://YOUR_PROJECT_REF.supabase.co';
+const supabaseKey = 'PUBLIC_ANON_KEY';
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+```
+
+Store sensitive keys in environment variables when deploying. ✅

--- a/hermes-extension/webpack.config.cjs
+++ b/hermes-extension/webpack.config.cjs
@@ -1,5 +1,6 @@
 const path = require('path');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+const webpack = require('webpack');
 
 module.exports = {
   mode: 'production',
@@ -74,7 +75,12 @@ module.exports = {
     ]
   },
   plugins: [
-    new ForkTsCheckerWebpackPlugin()
+    new ForkTsCheckerWebpackPlugin(),
+    // Build-time flags to toggle telemetry and feature sets 🎛️
+    new webpack.DefinePlugin({
+      'process.env.ENABLE_TELEMETRY': JSON.stringify(process.env.ENABLE_TELEMETRY ?? 'true'),
+      'process.env.FEATURE_SET': JSON.stringify(process.env.FEATURE_SET ?? 'default')
+    })
   ],
   optimization: {
     splitChunks: {


### PR DESCRIPTION
## Summary
- add build-time flags for telemetry and feature sets
- add Firebase and Supabase snippets for serverless setups
- document GitHub Pages and Netlify hosting for plugin assets

## Testing
- `CI=true npm test` (hermes-extension)
- `npm test` (server)


------
https://chatgpt.com/codex/tasks/task_e_68924007f37c8332976b42794ee0fc69