### PR TITLE
feat: add dev build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,8 @@ PRs are welcome. For suggestions or issues, please use the Issues tab.
 1. `cd hermes-extension`
 2. (optional) Run `npm install` to install dev dependencies. The build script will install them automatically if missing.
 3. From inside `hermes-extension/`, run `npm run build` to bundle `src/` into a `dist/` folder. This `dist/` directory is excluded from version control via `.gitignore`.
-4. Load the `hermes-extension` directory in Chrome as an unpacked extension.
+4. For live-reloading builds during development, run `npm run dev` instead. 🎉
+5. Load the `hermes-extension` directory in Chrome as an unpacked extension.
 
 > **Author:** Justin
 

--- a/hermes-extension/package.json
+++ b/hermes-extension/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "prebuild": "npm install",
     "build": "webpack --mode=production",
+    "dev": "NODE_ENV=development webpack --watch",
     "test": "jest"
   },
   "keywords": [],

--- a/hermes-extension/webpack.config.cjs
+++ b/hermes-extension/webpack.config.cjs
@@ -2,7 +2,8 @@ const path = require('path');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
 module.exports = {
-  mode: 'production',
+  // Use NODE_ENV if set, otherwise default to production 🚀
+  mode: process.env.NODE_ENV || 'production',
   entry: {
     background: './src/react/background.ts',
     content: './src/react/content.tsx',


### PR DESCRIPTION
## Summary
- read webpack mode from NODE_ENV with production fallback
- add `npm run dev` script for watch mode
- document live-reload builds in README

## Testing
- `cd hermes-extension && npm test`
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68923bca7894833296323246ab1cf0eb