### PR TITLE
feat: add browser api wrapper for extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ PRs are welcome. For suggestions or issues, please use the Issues tab.
 3. From inside `hermes-extension/`, run `npm run build` to bundle `src/` into a `dist/` folder. This `dist/` directory is excluded from version control via `.gitignore`.
 4. For live-reloading builds during development, run `npm run dev` instead. 🎉
 5. Load the `hermes-extension` directory in Chrome as an unpacked extension.
+6. For Firefox, run `npm run build` then use `about:debugging` to load the folder as a temporary add-on.
 
 > **Author:** Justin
 

--- a/hermes-extension/src/react/background.ts
+++ b/hermes-extension/src/react/background.ts
@@ -1,11 +1,13 @@
 // src/react/background.ts
 
+import browser from './utils/browserApi';
+
 // Listen for messages from content scripts
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === 'SAVE_HERMES_DATA') {
-    chrome.storage.local.set({ [message.payload.key]: message.payload.value }, () => {
-      if (chrome.runtime.lastError) {
-        sendResponse({ success: false, error: chrome.runtime.lastError.message });
+    browser.storage.local.set({ [message.payload.key]: message.payload.value }, () => {
+      if (browser.runtime.lastError) {
+        sendResponse({ success: false, error: browser.runtime.lastError.message });
       } else {
         sendResponse({ success: true });
       }
@@ -15,9 +17,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
   if (message.type === 'GET_HERMES_INITIAL_DATA') {
     const keys = ['hermes_settings_v1_ext', 'hermes_profile_ext', 'hermes_macros_ext', 'hermes_theme_ext'];
-    chrome.storage.local.get(keys, (result) => {
-      if (chrome.runtime.lastError) {
-        sendResponse({ error: chrome.runtime.lastError.message });
+    browser.storage.local.get(keys, (result) => {
+      if (browser.runtime.lastError) {
+        sendResponse({ error: browser.runtime.lastError.message });
       } else {
         sendResponse({
           settings: result.hermes_settings_v1_ext || {},
@@ -32,19 +34,19 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 });
 
 // Setup for the extension icon click
-chrome.action.onClicked.addListener((tab) => {
+browser.action.onClicked.addListener((tab) => {
   if (tab.id) {
     // Check if the content script is already there before injecting
-    chrome.tabs.sendMessage(tab.id, { type: 'HERMES_PING' }, (response) => {
-      if (chrome.runtime.lastError) {
+    browser.tabs.sendMessage(tab.id, { type: 'HERMES_PING' }, (response) => {
+      if (browser.runtime.lastError) {
         // Script not there, inject it
-        chrome.scripting.executeScript({
+        browser.scripting.executeScript({
           target: { tabId: tab.id! },
-          files: [chrome.runtime.getURL('dist/content.js')],
+          files: [browser.runtime.getURL('dist/content.js')],
         });
       } else {
         // Script is there, maybe tell it to show/hide
-        chrome.tabs.sendMessage(tab.id, { type: 'HERMES_TOGGLE_UI' });
+        browser.tabs.sendMessage(tab.id, { type: 'HERMES_TOGGLE_UI' });
       }
     });
   }

--- a/hermes-extension/src/react/options.tsx
+++ b/hermes-extension/src/react/options.tsx
@@ -2,8 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { AffirmationToggle } from './lib/components';
 import { themeOptions } from './themes/themeOptions';
-
-declare const chrome: any;
+import browser from './utils/browserApi';
 
 const THEME_KEY = 'hermes_theme_ext';
 const CUSTOM_THEMES_KEY = 'hermes_custom_themes_ext';
@@ -19,7 +18,7 @@ function OptionsApp() {
   const [current, setCurrent] = useState('dark');
 
   useEffect(() => {
-    chrome.storage.local.get([THEME_KEY, CUSTOM_THEMES_KEY, 'hermes_built_in_themes'], (data: any) => {
+    browser.storage.local.get([THEME_KEY, CUSTOM_THEMES_KEY, 'hermes_built_in_themes'], (data: any) => {
       const builtin = data.hermes_built_in_themes ? JSON.parse(data.hermes_built_in_themes) : {};
       const customThemes = data[CUSTOM_THEMES_KEY] ? JSON.parse(data[CUSTOM_THEMES_KEY]) : {};
       setBuiltIn(builtin);
@@ -30,11 +29,11 @@ function OptionsApp() {
 
   const saveTheme = (val: string) => {
     setCurrent(val);
-    chrome.storage.local.set({ [THEME_KEY]: val });
+    browser.storage.local.set({ [THEME_KEY]: val });
   };
 
   const exportThemes = () => {
-    chrome.storage.local.get([CUSTOM_THEMES_KEY], (data: any) => {
+    browser.storage.local.get([CUSTOM_THEMES_KEY], (data: any) => {
       const blob = new Blob([data[CUSTOM_THEMES_KEY] || '{}'], { type: 'application/json' });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
@@ -51,7 +50,7 @@ function OptionsApp() {
     reader.onload = () => {
       try {
         const obj = JSON.parse(reader.result as string);
-        chrome.storage.local.set({ [CUSTOM_THEMES_KEY]: JSON.stringify(obj) }, () => setCustom(obj));
+        browser.storage.local.set({ [CUSTOM_THEMES_KEY]: JSON.stringify(obj) }, () => setCustom(obj));
       } catch (e) {
         console.error('Invalid theme JSON', e);
       }

--- a/hermes-extension/src/react/services/affirmationService.ts
+++ b/hermes-extension/src/react/services/affirmationService.ts
@@ -1,4 +1,5 @@
 import { saveDataToBackground } from './storageService';
+import browser from '../utils/browserApi';
 
 const AFFIRM_KEY = 'hermes_affirmations_state_ext';
 let overlayEl: HTMLDivElement | null = null;
@@ -56,6 +57,6 @@ export function setAffirmations(enabled: boolean) {
 
 export function getAffirmationState(): Promise<boolean> {
   return new Promise(resolve => {
-    chrome.storage.local.get([AFFIRM_KEY], res => resolve(!!res[AFFIRM_KEY]));
+    browser.storage.local.get([AFFIRM_KEY], res => resolve(!!res[AFFIRM_KEY]));
   });
 }

--- a/hermes-extension/src/react/services/domScannerService.ts
+++ b/hermes-extension/src/react/services/domScannerService.ts
@@ -6,7 +6,7 @@ export interface SiteConfig {
   lastUpdated: string;
 }
 
-declare const chrome: any;
+import browser from '../utils/browserApi';
 
 function getSelector(el: Element): string {
   if ((el as HTMLElement).id) {
@@ -55,10 +55,10 @@ export function scanDOM(): SiteConfig {
 
 export async function ensureSiteConfig() {
   const site = location.hostname.toLowerCase();
-  const existing = await chrome.runtime.sendMessage({ type: 'GET_SITE_CONFIG', payload: { site } });
+  const existing = await browser.runtime.sendMessage({ type: 'GET_SITE_CONFIG', payload: { site } });
   if (existing && existing.success) return;
   const config = scanDOM();
-  const result = await chrome.runtime.sendMessage({ type: 'SAVE_SITE_CONFIG', payload: { site, config } });
+  const result = await browser.runtime.sendMessage({ type: 'SAVE_SITE_CONFIG', payload: { site, config } });
   if (result && result.success) {
     alert(`Hermes: Config saved for ${site}`);
   }

--- a/hermes-extension/src/react/services/storageService.ts
+++ b/hermes-extension/src/react/services/storageService.ts
@@ -1,12 +1,14 @@
 // src/react/services/storageService.ts
 
+import browser from '../utils/browserApi';
+
 export function saveDataToBackground(key: string, data: any): Promise<boolean> {
   return new Promise((resolve, reject) => {
-    chrome.runtime.sendMessage(
+    browser.runtime.sendMessage(
       { type: 'SAVE_HERMES_DATA', payload: { key, value: data } },
       (response: any) => {
-        if (chrome.runtime.lastError) {
-          reject(chrome.runtime.lastError.message);
+        if (browser.runtime.lastError) {
+          reject(browser.runtime.lastError.message);
           return;
         }
         if (response && response.success) {
@@ -21,6 +23,6 @@ export function saveDataToBackground(key: string, data: any): Promise<boolean> {
 
 export function getInitialData(): Promise<any> {
   return new Promise(resolve => {
-    chrome.runtime.sendMessage({ type: 'GET_HERMES_INITIAL_DATA' }, resolve);
+    browser.runtime.sendMessage({ type: 'GET_HERMES_INITIAL_DATA' }, resolve);
   });
 }

--- a/hermes-extension/src/react/utils/browserApi.ts
+++ b/hermes-extension/src/react/utils/browserApi.ts
@@ -1,0 +1,23 @@
+declare const chrome: any;
+declare const browser: any;
+
+function getBrowser() {
+  return typeof chrome !== 'undefined'
+    ? chrome
+    : typeof browser !== 'undefined'
+    ? browser
+    : undefined;
+}
+
+const browserApi = new Proxy(
+  {},
+  {
+    get(_target, prop) {
+      const api = getBrowser();
+      const value = api && (api as any)[prop];
+      return typeof value === 'function' ? value.bind(api) : value;
+    }
+  }
+) as any;
+
+export default browserApi;


### PR DESCRIPTION
## Summary
- add browser API utility to support Firefox
- replace chrome calls with wrapper across extension
- document Firefox build steps

## Testing
- `cd hermes-extension && npm test`
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689340dbbf788332b76cb1a3d7e9c4e2