### PR TITLE
feat: add extension packaging script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ See [CHANGELOG](CHANGELOG.md) for full release notes.
 ### Installation
 1. Run `./setup.sh` to install server and extension dependencies.
 2. Build the extension: `cd hermes-extension && npm run build`.
-3. From inside `hermes-extension/`, run `npm run dev` to watch and rebuild files during development.
-4. Load the `hermes-extension` folder in Chrome as an unpacked extension.
+3. Package the extension: `cd hermes-extension && npm run package` to produce a ready-to-install ZIP.
+4. From inside `hermes-extension/`, run `npm run dev` to watch and rebuild files during development.
+5. Load the `hermes-extension` folder in Chrome as an unpacked extension.
 
 `npm run dev` automatically rebuilds the React UI as you edit files. Run `npm run build` again for a one-off rebuild if the watcher is stopped.
 
@@ -369,8 +370,9 @@ PRs are welcome. For suggestions or issues, please use the Issues tab.
 1. `cd hermes-extension`
 2. (optional) Run `npm install` to install dev dependencies. The build script will install them automatically if missing.
 3. From inside `hermes-extension/`, run `npm run build` to bundle `src/` into a `dist/` folder. This `dist/` directory is excluded from version control via `.gitignore`.
-4. For live-reloading builds during development, run `npm run dev` instead. 🎉
-5. Load the `hermes-extension` directory in Chrome as an unpacked extension.
+4. Run `npm run package` to produce a ready-to-install ZIP.
+5. For live-reloading builds during development, run `npm run dev` instead. 🎉
+6. Load the `hermes-extension` directory in Chrome as an unpacked extension.
 
 > **Author:** Justin
 

--- a/hermes-extension/package.json
+++ b/hermes-extension/package.json
@@ -7,7 +7,8 @@
     "prebuild": "npm install",
     "build": "webpack --mode=production",
     "dev": "NODE_ENV=development webpack --watch",
-    "test": "jest"
+    "test": "jest",
+    "package": "node scripts/build-extension.js"
   },
   "keywords": [],
   "author": "",

--- a/hermes-extension/scripts/build-extension.js
+++ b/hermes-extension/scripts/build-extension.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// 📍 Translate ESM metadata into friendly paths
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// 🌟 Root directory for the extension goodies
+const rootDir = path.resolve(__dirname, '..');
+const distDir = path.join(rootDir, 'dist');
+
+function bumpVersion() {
+  // 🔢 Give the manifest a fresh patch version
+  const manifestPath = path.join(rootDir, 'manifest.json');
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const parts = manifest.version.split('.').map(Number);
+  parts[2] = (parts[2] || 0) + 1;
+  manifest.version = parts.join('.');
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+  return manifest.version;
+}
+
+function runWebpack() {
+  // 🛠️ Build the React/TS bundle via webpack
+  execSync('npm run build', { cwd: rootDir, stdio: 'inherit' });
+}
+
+function copyAssets() {
+  // 📦 Move static assets alongside the build output
+  fs.mkdirSync(distDir, { recursive: true });
+  const files = ['manifest.json', 'options.html', 'i18n.js'];
+  files.forEach(file => {
+    fs.copyFileSync(path.join(rootDir, file), path.join(distDir, file));
+  });
+  fs.cpSync(path.join(rootDir, 'configs'), path.join(distDir, 'configs'), { recursive: true });
+}
+
+function zipDist() {
+  // 🎁 Zip everything up for easy installation
+  execSync('zip -r hermes-extension.zip .', { cwd: distDir, stdio: 'inherit' });
+}
+
+function main() {
+  const newVersion = bumpVersion();
+  console.log(`Packaging Hermes extension v${newVersion}...`);
+  runWebpack();
+  copyAssets();
+  zipDist();
+  console.log('Done! Find your zip in dist/hermes-extension.zip');
+}
+
+main();


### PR DESCRIPTION
## Summary
- add packaging script to build, copy assets, bump manifest version and zip the extension
- wire up `npm run package` and document packaging in the README
- convert packaging script to ESM so it runs under the extension's module configuration

## Testing
- `cd hermes-extension && npm test`
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689340eaf8148332bfaac837723c8686